### PR TITLE
Feature/gpx

### DIFF
--- a/backend/aiproject/urls.py
+++ b/backend/aiproject/urls.py
@@ -13,13 +13,13 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from core.views import *
+from core.views import home
 from django.conf.urls import include
 from django.contrib import admin
 from django.urls import path, re_path
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
-from rest_framework import permissions, routers
+from rest_framework import permissions
 
 schema_view = get_schema_view(
     openapi.Info(
@@ -33,16 +33,6 @@ schema_view = get_schema_view(
     public=True,
     permission_classes=[permissions.AllowAny],
 )
-
-
-router = routers.DefaultRouter()
-router.register(r"dataset", DatasetViewSet)  # gets crud operation for the model dataset
-router.register(r"aoi", AOIViewSet)  # gets crud operation for the model dataset
-router.register(r"label", LabelViewSet)  # gets crud operation for the model dataset
-router.register(
-    r"training", TrainingViewSet
-)  # gets crud operation for the model dataset
-router.register(r"model", ModelViewSet)  # gets crud operation for the model dataset
 
 
 urlpatterns = [
@@ -63,15 +53,6 @@ urlpatterns = [
     ),
     path("api/", home, name="home"),
     path("api/v1/auth/", include("login.urls")),  # add auth urls
+    path("api/v1/", include("core.urls")),  # add core urls
     path("api/admin/", admin.site.urls),
-    path(
-        "api/v1/", include(router.urls)
-    ),  # adding all the api to version 1 project is in development
-    path("api/v1/label/osm/fetch/<int:aoi_id>/", RawdataApiView.as_view()),
-    path("api/v1/dataset/image/build/", ImageDownloadView.as_view()),
-    path("api/v1/download/<int:dataset_id>/", download_training_data),
-    path("api/v1/training/status/<str:run_id>/", run_task_status),
-    path("api/v1/training/publish/<int:training_id>/", publish_training),
-    path("api/v1/prediction/", PredictionView.as_view()),
-    path("api/v1/status/", APIStatus.as_view()),
 ]

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,0 +1,39 @@
+from django.conf.urls import include
+from django.urls import path
+from rest_framework import routers
+
+# now import the views.py file into this code
+from .views import (
+    AOIViewSet,
+    APIStatus,
+    DatasetViewSet,
+    ImageDownloadView,
+    LabelViewSet,
+    ModelViewSet,
+    PredictionView,
+    RawdataApiView,
+    TrainingViewSet,
+    download_training_data,
+    publish_training,
+    run_task_status,
+)
+
+# CURD Block
+router = routers.DefaultRouter()
+router.register(r"dataset", DatasetViewSet)
+router.register(r"aoi", AOIViewSet)
+router.register(r"label", LabelViewSet)
+router.register(r"training", TrainingViewSet)
+router.register(r"model", ModelViewSet)
+
+
+urlpatterns = [
+    path("", include(router.urls)),
+    path("label/osm/fetch/<int:aoi_id>/", RawdataApiView.as_view()),
+    path("dataset/image/build/", ImageDownloadView.as_view()),
+    path("download/<int:dataset_id>/", download_training_data),
+    path("training/status/<str:run_id>/", run_task_status),
+    path("training/publish/<int:training_id>/", publish_training),
+    path("prediction/", PredictionView.as_view()),
+    path("status/", APIStatus.as_view()),
+]

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -14,6 +14,7 @@ from .views import (
     PredictionView,
     RawdataApiView,
     TrainingViewSet,
+    TrainingWorkspaceView,
     download_training_data,
     publish_training,
     run_task_status,
@@ -38,4 +39,6 @@ urlpatterns = [
     path("prediction/", PredictionView.as_view()),
     path("status/", APIStatus.as_view()),
     path("aoi/gpx/<int:aoi_id>/", GenerateGpxView.as_view()),
+    path("workspace/<str:lookup_dir>/", TrainingWorkspaceView.as_view()),
+    # path("training/workspace/<str:file_path>/", dir_download),
 ]

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -7,6 +7,7 @@ from .views import (
     AOIViewSet,
     APIStatus,
     DatasetViewSet,
+    GenerateGpxView,
     ImageDownloadView,
     LabelViewSet,
     ModelViewSet,
@@ -36,4 +37,5 @@ urlpatterns = [
     path("training/publish/<int:training_id>/", publish_training),
     path("prediction/", PredictionView.as_view()),
     path("status/", APIStatus.as_view()),
+    path("aoi/gpx/<int:aoi_id>/", GenerateGpxView.as_view()),
 ]

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -426,10 +426,6 @@ class APIStatus(APIView):
 
 
 class GenerateGpxView(APIView):
-
-    # @swagger_auto_schema(
-    #     request_body=ImageDownloadSerializer, responses={status.HTTP_200_OK: "ok"}
-    # )
     def get(self, request, aoi_id: int):
         aoi = get_object_or_404(AOI, id=aoi_id)
         # Convert the polygon field to GPX format

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -12,7 +12,6 @@ import tensorflow as tf
 from celery import current_app
 from celery.result import AsyncResult
 from django.conf import settings
-from django.core.serializers import serialize
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django_filters.rest_framework import DjangoFilterBackend

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -439,8 +439,30 @@ class GenerateGpxView(APIView):
             # Append each point as a GPXWaypoint to the GPXTrackSegment
             gpx_segment.points.append(GPXWaypoint(point[1], point[0]))
         gpx.creator = "fAIr Backend"
-        gpx.name = f"AOI of id {aoi_id} , Don't Edit this Boundary"
+        gpx_track.name = f"AOI of id {aoi_id} , Don't Edit this Boundary"
+        gpx_track.description = "This is coming from AI Assisted Mapping - fAIr : HOTOSM , Map inside this boundary and go back to fAIr UI"
         gpx.time = datetime.now()
         gpx.link = "https://github.com/hotosm/fAIr"
         gpx.link_text = "AI Assisted Mapping - fAIr : HOTOSM"
         return HttpResponse(gpx.to_xml(), content_type="text/xml; charset=utf-8")
+
+
+class TrainingWorkspaceView(APIView):
+    def get(self, request, lookup_dir: str = None):
+        """List out status of training workspace"""
+        # {workspace_dir:{file_name:{size:20,type:file},dir_name:{size:20,len:4,type:dir}}}
+        base_dir = settings.TRAINING_WORKSPACE
+        workspace = os.listdir(base_dir)
+
+        for item in workspace:
+            item_path = os.path.join(base_dir, item)
+            if os.path.isfile(item_path):
+                is_type = "file"
+                size = os.path.getsize(size)
+            elif os.path.isdir(item_path):
+                is_type = "dir"
+                length = len(item_path)
+
+        return Response(
+            {"num_files": num_files, "size": size}, status=status.HTTP_201_CREATED
+        )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,3 +16,4 @@ redis==4.4.0
 django_celery_results==2.4.0
 flower==1.2.0
 validators==0.20.0
+gpxpy==1.5.0


### PR DESCRIPTION
- Resolve #44 

Introduces new GET Public API for the GPX which is : 
```
/api/v1/aoi/gpx/{aoi_id}/
```
Returns Response as GPX like this : 
```
<?xml version="1.0" encoding="UTF-8"?>
  <gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="fAIr Backend">
    <metadata>
      <name>AOI of id 9 , Don't Edit this Boundary</name>
      <link href="https://github.com/hotosm/fAIr">
        <text>AI Assisted Mapping - fAIr : HOTOSM</text>
      </link>
      <time>2023-01-23T12:06:11.557220Z</time>
    </metadata>
    <trk>
      <trkseg>
        <trkpt lat="0.352933559055294" lon="32.59368896484375">
        </trkpt>
        <trkpt lat="0.354306823915566" lon="32.59368896484375">
        </trkpt>
        <trkpt lat="0.354306823915566" lon="32.595062255859375">
        </trkpt>
        <trkpt lat="0.352933559055294" lon="32.595062255859375">
        </trkpt>
        <trkpt lat="0.352933559055294" lon="32.59368896484375">
        </trkpt>
      </trkseg>
    </trk>
  </gpx>
  ```
  Raises 404 not found error if AOI is not preset 