### PR TITLE
Added documentation to README.md for fAIr

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,9 +1,25 @@
 ![example workflow](https://github.com/omranlm/TDB/actions/workflows/backend_build.yml/badge.svg)
 ![example workflow](https://github.com/omranlm/TDB/actions/workflows/frontend_build.yml/badge.svg)
-
-AI project for Training Dataset using OSM. 
-
 Navigate to Backend or Frontend to get Installation Instructions.
+ 
+# fAIr: AI-assisted Mapping
+fAIr is an open AI-assisted mapping service developed by the [Humanitarian OpenStreetMap Team (HOT)](https://www.hotosm.org/) that aims to improve the efficiency and accuracy of mapping efforts for humanitarian purposes. The service uses AI models, specifically computer vision techniques, to detect objects such as buildings, roads, waterways, and trees from satellite and UAV imagery.
+
+The name fAIr is derived from the following terms:
+
+- **f**: for freedom and free and open-source software
+- **AI**: for Artificial Intelligence
+- **r**: for resilience and our responsibility for our communities and the role we play within humanitarian mapping
+
+## Features
+- Intuitive and fair AI-assisted mapping tool
+- Open-source AI models created and trained by local communities
+- Uses open-source satellite and UAV imagery from HOT's OpenAerialMap (OAM) to detect map features and suggest additions to OpenStreetMap (OSM)
+- Constant feedback loop to eliminate model biases and ensure models are relevant to local communities
+
+Unlike other AI data producers, fAIr is a free and open-source AI service that allows OSM community members to create and train their own AI models for mapping in their region of interest and/or humanitarian need. The goal of fAIr is to provide access to AI-assisted mapping across mobile and in-browser editors, using community-created AI models, and to ensure that the models are relevant to the communities where the maps are being created to improve the conditions of the people living there.
+
+To eliminate model biases, fAIr is built to work with the local communities and receive constant feedback on the models, which will result in the progressive intelligence of computer vision models. The AI models suggest detected features to be added to OpenStreetMap (OSM), but mass import into OSM is not planned. Whenever an OSM mapper uses the AI models for assisted mapping and completes corrections, fAIr can take those corrections as feedback to enhance the AI model’s accuracy.
 
 # Product Roadmap
 See below a suggested product roadmap [subject to change] that provides high-level overview for planned work.


### PR DESCRIPTION
Currently, the [README.md](https://github.com/hotosm/fAIr/blob/master/Readme.md) doesn't describe what fAIr is.

 This PR describes fAIr and some of its features for a brief understanding of the tool.