### PR TITLE
Hot Fix : Patch on feedback labels overwrite

### DIFF
--- a/backend/core/admin.py
+++ b/backend/core/admin.py
@@ -7,12 +7,12 @@ from .models import *
 
 
 @admin.register(Dataset)
-class DatasetAdmin(geoadmin.GeoModelAdmin):
+class DatasetAdmin(geoadmin.OSMGeoAdmin):
     list_display = ["name", "created_by"]
 
 
 @admin.register(Model)
-class ModelAdmin(geoadmin.GeoModelAdmin):
+class ModelAdmin(geoadmin.OSMGeoAdmin):
     list_display = ["get_dataset_id", "name", "status", "created_at", "created_by"]
 
     def get_dataset_id(self, obj):
@@ -22,7 +22,7 @@ class ModelAdmin(geoadmin.GeoModelAdmin):
 
 
 @admin.register(Training)
-class TrainingAdmin(geoadmin.GeoModelAdmin):
+class TrainingAdmin(geoadmin.OSMGeoAdmin):
     list_display = [
         "get_model_id",
         "description",
@@ -39,12 +39,11 @@ class TrainingAdmin(geoadmin.GeoModelAdmin):
     get_model_id.short_description = "Model"
 
 
-# dsaf
 @admin.register(FeedbackAOI)
-class FeedbackAOIAdmin(geoadmin.GeoModelAdmin):
+class FeedbackAOIAdmin(geoadmin.OSMGeoAdmin):
     list_display = ["training", "user"]
 
 
-@admin.register(FeedbackLabel)
-class FeedbackLabelAdmin(geoadmin.GeoModelAdmin):
-    list_display = ["feedback_aoi", "created_at"]
+@admin.register(Feedback)
+class FeedbackAdmin(geoadmin.OSMGeoAdmin):
+    list_display = ["feedback_type", "training", "user", "created_at"]

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -109,7 +109,7 @@ class LabelSerializer(GeoFeatureModelSerializer):
         # auto_bbox = True
         fields = "__all__"
 
-        read_only_fields = ("created_at", "osm_id")
+        # read_only_fields = ("created_at", "osm_id")
 
 
 class FeedbackLabelSerializer(GeoFeatureModelSerializer):
@@ -117,7 +117,7 @@ class FeedbackLabelSerializer(GeoFeatureModelSerializer):
         model = FeedbackLabel
         geo_field = "geom"
         fields = "__all__"
-        read_only_fields = ("created_at", "osm_id")
+        # read_only_fields = ("created_at", "osm_id")
 
 
 class LabelFileSerializer(

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -244,8 +244,8 @@ class LabelViewSet(viewsets.ModelViewSet):
 
 
 class RawdataApiFeedbackView(APIView):
-    authentication_classes = [OsmAuthentication]
-    permission_classes = [IsOsmAuthenticated]
+    # authentication_classes = [OsmAuthentication]
+    # permission_classes = [IsOsmAuthenticated]
 
     def post(self, request, feedbackaoi_id, *args, **kwargs):
         """Downloads available osm data as labels within given feedback aoi


### PR DESCRIPTION
Fixes feedback labels overwrite problem , now osm_id is populated and when fetched again they will be replaced if exists 