### PR TITLE
Fix : Prediction Error when temp dir isn't present on machine

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -543,7 +543,7 @@ class PredictionView(APIView):
                 bbox, zoom_level, DEFAULT_TILE_SIZE
             )
             temp_path = f"temp/{uuid.uuid4()}/"
-            os.mkdir(temp_path)
+            os.makedirs(temp_path,exist_ok=True)
             try:
                 download_imagery(
                     start,


### PR DESCRIPTION
- This PR Fixes the bug when there is no default temp dir on machine , it will create and make sure parent is present 
- Minor fix 