### PR TITLE
HOTFIX : Status code on the training publish endpoint 

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -95,7 +95,7 @@ class DatasetViewSet(
 class TrainingSerializer(
     serializers.ModelSerializer
 ):  # serializers are used to translate models objects to api
-
+    user = UserSerializer(read_only=True)
     multimasks = serializers.BooleanField(required=False, default=False)
     input_contact_spacing = serializers.IntegerField(
         required=False, default=8, min_value=0, max_value=20

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -729,10 +729,10 @@ def publish_training(request, training_id: int):
     training_instance = get_object_or_404(Training, id=training_id)
 
     if training_instance.status != "FINISHED":
-        return Response("Training is not FINISHED", status=404)
+        return Response("Training is not FINISHED", status=409)
     if training_instance.accuracy < 70:
         return Response(
-            "Can't publish the training since its accuracy is below 70%", status=404
+            "Can't publish the training since its accuracy is below 70%", status=403
         )
 
     model_instance = get_object_or_404(Model, id=training_instance.model.id)


### PR DESCRIPTION
## What does this PR do ? 
- This PR fixes the status code on the training publish API endpoint 
- Adds user information on the training endpoint 

## Consideration : 
I haven't looked in to other status code for other APIS atm , will fix those when development progresses , Kindly let me know ! 

## How to test ?  

- When training is running it can't be published and you should get the 409 status code , Which is a conflict ( System is doing the training atm and can't be published ) 
- 403 is used if training accuracy is less than 70 % , system understand the request but its forbidden to publish the training of low accuracy  

