### PR TITLE
HOTFIX : Bypass permission for training accuracy graph download

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -69,7 +69,7 @@ urlpatterns = [
     path(
         "feedback-aoi/gpx/<int:feedback_aoi_id>/", GenerateFeedbackAOIGpxView.as_view()
     ),
-    path("workspace/", TrainingWorkspaceView.as_view()),
+    # path("workspace/", TrainingWorkspaceView.as_view()),
     path(
         "workspace/download/<path:lookup_dir>/", TrainingWorkspaceDownloadView.as_view()
     ),

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -784,7 +784,18 @@ class TrainingWorkspaceView(APIView):
     @method_decorator(cache_page(60 * 15))
     # @method_decorator(vary_on_headers("access-token"))
     def get(self, request, lookup_dir):
-        """List out status of training workspace : size in bytes"""
+        """
+        List the status of the training workspace.
+
+        ### Returns:
+        - **Size**: The total size of the workspace in bytes.
+        - **dir/file**: The current dir/file on the lookup_dir.
+
+        ### Workspace Structure:
+        By default, the training workspace is organized as follows:
+        - Training files are stored in the directory: `dataset{dataset_id}/output/training_{training}`
+        """
+
         # {workspace_dir:{file_name:{size:20,type:file},dir_name:{size:20,len:4,type:dir}}}
         base_dir = settings.TRAINING_WORKSPACE
         if lookup_dir:

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -783,7 +783,7 @@ class GenerateFeedbackAOIGpxView(APIView):
 class TrainingWorkspaceView(APIView):
     @method_decorator(cache_page(60 * 15))
     # @method_decorator(vary_on_headers("access-token"))
-    def get(self, request, lookup_dir=None):
+    def get(self, request, lookup_dir):
         """List out status of training workspace : size in bytes"""
         # {workspace_dir:{file_name:{size:20,type:file},dir_name:{size:20,len:4,type:dir}}}
         base_dir = settings.TRAINING_WORKSPACE

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -781,6 +781,8 @@ class GenerateFeedbackAOIGpxView(APIView):
 
 
 class TrainingWorkspaceView(APIView):
+    @method_decorator(cache_page(60 * 15))
+    # @method_decorator(vary_on_headers("access-token"))
     def get(self, request, lookup_dir=None):
         """List out status of training workspace : size in bytes"""
         # {workspace_dir:{file_name:{size:20,type:file},dir_name:{size:20,len:4,type:dir}}}
@@ -813,6 +815,15 @@ class TrainingWorkspaceView(APIView):
 class TrainingWorkspaceDownloadView(APIView):
     authentication_classes = [OsmAuthentication]
     permission_classes = [IsOsmAuthenticated]
+
+    def dispatch(self, request, *args, **kwargs):
+        lookup_dir = kwargs.get("lookup_dir")
+        if lookup_dir.endswith("training_validation_sparse_categorical_accuracy.png"):
+            # bypass
+            self.authentication_classes = []
+            self.permission_classes = []
+
+        return super().dispatch(request, *args, **kwargs)
 
     def get(self, request, lookup_dir):
         base_dir = os.path.join(settings.TRAINING_WORKSPACE, lookup_dir)
@@ -860,6 +871,7 @@ class BannerViewSet(viewsets.ModelViewSet):
     authentication_classes = [OsmAuthentication]
     permission_classes = [IsAdminUser, IsStaffUser]
     public_methods = ["GET"]
+    pagination_class = None
 
     def get_queryset(self):
         now = timezone.now()
@@ -869,7 +881,7 @@ class BannerViewSet(viewsets.ModelViewSet):
 
 
 @cache_page(60 * 15)  ## Cache for 15 mins
-# @vary_on_cookie , if you wanna do user specific cache
+# @vary_on_cookie
 @api_view(["GET"])
 def get_kpi_stats(request):
     total_models_with_status_published = Model.objects.filter(status=0).count()


### PR DESCRIPTION
## What does this PR do ? 
- Implements bypass logic to allow user downloading the accuracy graph without an authentication 
- Removes the pagination on banner endpoint 
- Implements caching on training-workspace view 

## Consideration : 

I have bypassed the logic for accuracy graphs  , this should allow user without an authentication to access the single file , however for other files it requires login still ! 
I am not fully confident on cache , server cache is not a best way to cache the training workspace view , I recommend cache on the frontend page itself ! However in-order to make user experience smooth and reduce frontend development load I have implemented the cache in server to  the workspace view for now ! 

Later on , streaming EFS to endpoint will be more efficient than manually going through the folders from python , This can be added as enhancement for this endpoint , I am aware that this endpoint will not be efficient when training files keep growing on the server ! 

## How to test ? 
Try fetching the accuracy graph without an authentication it should work ! 