### PR TITLE
chore: added predictor api and osm status to envs

### DIFF
--- a/frontend/.env.sample
+++ b/frontend/.env.sample
@@ -145,3 +145,15 @@ VITE_MAX_GEOJSON_FILE_UPLOAD_FOR_TRAINING_AREAS = 10
 # Data type: Positive Integer (e.g., 1).
 # Default value: 10 (10 GeoJSON files, assumming each file has a single AOI).
 VITE_MAX_ACCEPTABLE_POLYGON_IN_TRAINING_AREA_GEOJSON_FILE = 10
+
+
+# The predictor API URL.
+# Data type: String (e.g., https://predictor-dev.fair.hotosm.org/predict/).
+# Default value: https://predictor-dev.fair.hotosm.org/predict/.
+VITE_FAIR_PREDICTOR_API_URL =  https://predictor-dev.fair.hotosm.org/predict/.
+
+
+# The OSM Database status API.
+# Data type: String (e.g., https://api-prod.raw-data.hotosm.org/v1/status/).
+# Default value: https://api-prod.raw-data.hotosm.org/v1/status/.
+VITE_OSM_DATABASE_STATUS_API_URL: https://api-prod.raw-data.hotosm.org/v1/status/

--- a/frontend/src/config/env.ts
+++ b/frontend/src/config/env.ts
@@ -233,4 +233,17 @@ export const ENVS = {
   */
   MAX_ACCEPTABLE_POLYGON_IN_TRAINING_AREA_GEOJSON_FILE: import.meta.env
     .VITE_MAX_ACCEPTABLE_POLYGON_IN_TRAINING_AREA_GEOJSON_FILE,
+
+  /**
+    The predictor API URL.
+    Data type: String (e.g., https://predictor-dev.fair.hotosm.org/predict/).
+    Default value: https://predictor-dev.fair.hotosm.org/predict/.
+   */
+  FAIR_PREDICTOR_API_URL: import.meta.env.VITE_FAIR_PREDICTOR_API_URL,
+  /**
+    The OSM Database status API.
+    Data type: String (e.g., https://api-prod.raw-data.hotosm.org/v1/status/).
+    Default value: https://api-prod.raw-data.hotosm.org/v1/status/.
+   */
+  OSM_DATABASE_STATUS_API_URL: import.meta.env.VITE_OSM_DATABASE_STATUS_API_URL,
 };

--- a/frontend/src/services/api-routes.ts
+++ b/frontend/src/services/api-routes.ts
@@ -1,3 +1,5 @@
+import { ENVS } from '@/config/env';
+
 /**
  * The backend API endpoints.
  */
@@ -10,12 +12,11 @@ export const API_ENDPOINTS = {
 
   // OSM Database
 
-  GET_OSM_DATABASE_LAST_UPDATED:
-    "https://api-prod.raw-data.hotosm.org/v1/status/",
+  GET_OSM_DATABASE_LAST_UPDATED: ENVS.OSM_DATABASE_STATUS_API_URL || "https://api-prod.raw-data.hotosm.org/v1/status/",
 
   // Predict
 
-  GET_MODEL_PREDICTIONS: "https://predictor-dev.fair.hotosm.org/predict/",
+  GET_MODEL_PREDICTIONS: ENVS.FAIR_PREDICTOR_API_URL || "https://predictor-dev.fair.hotosm.org/predict/",
 
   // Feedbacks
 

--- a/frontend/src/utils/geo/geo-utils.ts
+++ b/frontend/src/utils/geo/geo-utils.ts
@@ -1,17 +1,16 @@
-import bbox from "@turf/bbox";
-import { API_ENDPOINTS, BASE_API_URL } from "@/services";
-import { calculateGeoJSONArea } from "./geometry-utils";
+import bbox from '@turf/bbox';
+import { API_ENDPOINTS, BASE_API_URL } from '@/services';
+import { calculateGeoJSONArea } from './geometry-utils';
+import { Feature, FeatureCollection } from 'geojson';
+import { geojsonToOsmPolygons } from './geojson-to-osm';
+import { showErrorToast, showSuccessToast } from '../general-utils';
 import {
-  FAIR_VERSION,
   JOSM_REMOTE_URL,
   MAX_TRAINING_AREA_SIZE,
   MIN_TRAINING_AREA_SIZE,
   OSM_HASHTAGS,
   TOAST_NOTIFICATIONS,
 } from "@/constants";
-import { Feature, FeatureCollection } from "geojson";
-import { geojsonToOsmPolygons } from "./geojson-to-osm";
-import { showErrorToast, showSuccessToast } from "../general-utils";
 
 /**
  * Creates a GeoJSON FeatureCollection
@@ -55,7 +54,7 @@ export const openInIDEditor = (
   const centerLat = (bottomLat + topLat) / 2;
   const centerLng = (leftLng + rightLng) / 2;
   const zoomLevel = 17;
-  let idEditorURL = `https://www.openstreetmap.org/edit?editor=id#disable_features=boundaries&gpx=${BASE_API_URL + API_ENDPOINTS.GET_TRAINING_AREA_GPX(aoiId)}&map=${zoomLevel}/${centerLat}/${centerLng}&background=custom:${encodeURIComponent(imageryURL)}&hashtags=${OSM_HASHTAGS}%23HOT-fAIr-${FAIR_VERSION},%23dataset-${datasetId},%23aoi-${aoiId}`;
+  let idEditorURL = `https://www.openstreetmap.org/edit?editor=id#disable_features=boundaries&gpx=${BASE_API_URL + API_ENDPOINTS.GET_TRAINING_AREA_GPX(aoiId)}&map=${zoomLevel}/${centerLat}/${centerLng}&background=custom:${encodeURIComponent(imageryURL)}&hashtags=${encodeURIComponent(OSM_HASHTAGS)},#dataset-${datasetId},#aoi-${aoiId}`;
   window.open(idEditorURL, "_blank", "noreferrer");
 };
 
@@ -126,6 +125,7 @@ export const openInJOSM = async (
       loadurl.searchParams.set("top", String(bounds[3]));
       loadurl.searchParams.set("left", String(bounds[0]));
       loadurl.searchParams.set("right", String(bounds[2]));
+      loadurl.searchParams.set("changeset_tags", `comment=${OSM_HASHTAGS}|source=${oamTileName}`);
       await fetch(loadurl);
       showSuccessToast(TOAST_NOTIFICATIONS.josmOpenSuccess);
     } catch (error) {


### PR DESCRIPTION
### What does this PR do?

This PR will be closing #313 by including the predictor API and the OSM status API in the environment variables. It also includes updates to the JOSM remote control function by including in the changeset the hashtags (set in the environment variable) and the oam as the imagery source.

### How to Test

Check the `frontend/.env.sample` and the `frontend/src/services/api-routes.ts` files to confirm.