### PR TITLE
Fix/start mapping hangs with large features

### DIFF
--- a/frontend/src/app/providers/models-provider.tsx
+++ b/frontend/src/app/providers/models-provider.tsx
@@ -8,7 +8,6 @@ import { BASE_MODELS, TrainingDatasetOption, TrainingType } from "@/enums";
 import { HOT_FAIR_MODEL_CREATION_SESSION_STORAGE_KEY } from "@/config";
 import { LngLatBoundsLike } from "maplibre-gl";
 import { useCreateTrainingDataset } from "@/features/model-creation/hooks/use-training-datasets";
-import { useGetTrainingDataset } from "@/features/models/hooks/use-dataset";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { useModelDetails } from "@/features/models/hooks/use-models";
 import { UseMutationResult } from "@tanstack/react-query";
@@ -305,20 +304,11 @@ export const ModelsProvider: React.FC<{
     isEditMode,
   );
 
-  const {
-    data: trainingDataset,
-    isPending: trainingDatasetIsPending,
-    isError: trainingDatasetIsError,
-  } = useGetTrainingDataset(
-    Number(data?.dataset),
-    Boolean(isEditMode && data?.dataset),
-  );
-
   // Will be used in the route validator component to delay the redirection for a while until the data are retrieved
   const validateEditMode =
     formData.selectedTrainingDatasetId !== "" && formData.tmsURL !== "";
 
-  // Fetch and prefill model details
+  // Fetch and prefill model details and training dataset
   useEffect(() => {
     if (!isEditMode || isPending || !data) return;
 
@@ -334,28 +324,17 @@ export const ModelsProvider: React.FC<{
     handleChange(MODEL_CREATION_FORM_NAME.MODEL_NAME, data.name ?? "");
     handleChange(
       MODEL_CREATION_FORM_NAME.SELECTED_TRAINING_DATASET_ID,
-      data.dataset,
+      data.dataset.id,
     );
-  }, [isEditMode, isError, isPending, data]);
-
-  // Fetch and prefill training dataset
-  useEffect(() => {
-    if (!isEditMode || trainingDatasetIsPending || trainingDatasetIsError)
-      return;
     handleChange(
       MODEL_CREATION_FORM_NAME.DATASET_NAME,
-      trainingDataset.name ?? "",
+      data.dataset.name ?? "",
     );
     handleChange(
       MODEL_CREATION_FORM_NAME.TMS_URL,
-      trainingDataset.source_imagery ?? "",
+      data.dataset.source_imagery ?? "",
     );
-  }, [
-    isEditMode,
-    trainingDatasetIsPending,
-    trainingDataset,
-    trainingDatasetIsError,
-  ]);
+  }, [isEditMode, isError, isPending, data]);
 
   useEffect(() => {
     // Cleanup the timeout on component unmount

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -334,8 +334,8 @@ const router = createBrowserRouter([
         },
       },
       /**
-      * Auth route ends.
-      */
+       * Auth route ends.
+       */
       /**
        * 404 route
        */

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -322,7 +322,7 @@ const router = createBrowserRouter([
        */
 
       /**
-       * Auth route
+       * Auth route starts.
        */
       {
         path: APPLICATION_ROUTES.AUTH_CALLBACK,
@@ -333,7 +333,9 @@ const router = createBrowserRouter([
           return { Component: AuthenticationCallbackPage };
         },
       },
-
+      /**
+      * Auth route ends.
+      */
       /**
        * 404 route
        */

--- a/frontend/src/app/routes/models/model-details-card.tsx
+++ b/frontend/src/app/routes/models/model-details-card.tsx
@@ -7,13 +7,12 @@ import { Image } from "@/components/ui/image";
 import { ModelDetailsSkeleton } from "@/features/models/components/skeletons";
 import { ModelFilesDialog } from "@/features/models/components/dialogs";
 import { StarStackIcon } from "@/components/ui/icons";
-import { TModelDetails, TTrainingDataset } from "@/types";
+import { TModelDetails } from "@/types";
 import { TrainingAreaDrawer } from "@/features/models/components/training-area-drawer";
 import { TrainingInProgressImage } from "@/assets/images";
 import { useAuth } from "@/app/providers/auth-provider";
 import { useDialog } from "@/hooks/use-dialog";
 import { useEffect } from "react";
-import { useGetTrainingDataset } from "@/features/models/hooks/use-dataset";
 import { useModelDetails } from "@/features/models/hooks/use-models";
 import { useNavigate, useParams } from "react-router-dom";
 import {
@@ -69,20 +68,9 @@ export const ModelDetailsPage = () => {
     openDialog: openModelEnhancementDialog,
   } = useDialog();
 
-  const {
-    isPending: isTrainingDatasetPending,
-    data: trainingDataset,
-    isError: isTrainingDatasetError,
-  } = useGetTrainingDataset(data?.dataset, !!data);
-
   const { isOpened, closeDialog, openDialog } = useDialog();
 
-  if (
-    isPending ||
-    isError ||
-    isTrainingDatasetPending ||
-    isTrainingDatasetError
-  ) {
+  if (isPending || isError) {
     return <ModelDetailsSkeleton />;
   }
 
@@ -91,20 +79,20 @@ export const ModelDetailsPage = () => {
       <ModelEnhancementDialog
         isOpened={isModelEnhancementDialogOpened}
         closeDialog={closeModelEnhancementDialog}
-        modelId={data?.id as string}
+        modelId={data?.id}
       />
       <TrainingAreaDrawer
         isOpened={isOpened}
         closeDialog={closeDialog}
-        trainingAreaId={data?.published_training as number}
-        tmsURL={trainingDataset?.source_imagery as string}
+        trainingAreaId={data.published_training}
+        tmsURL={data?.dataset?.source_imagery}
       />
       <Head title={`${data?.name} Model`} />
       <ModelFilesDialog
         closeDialog={closeModelFilesDialog}
         isOpened={isModelFilesDialogOpened}
-        trainingId={data?.published_training as number}
-        datasetId={data?.dataset as number}
+        trainingId={data?.published_training}
+        datasetId={data?.dataset?.id}
       />
       <BackButton className="mt-6" route={APPLICATION_ROUTES.MODELS} />
       <div className="my-12 flex flex-col gap-y-20">
@@ -112,9 +100,7 @@ export const ModelDetailsPage = () => {
           data={data as TModelDetails}
           openModelFilesDialog={openModelFilesDialog}
           openTrainingAreaDrawer={openDialog}
-          isError={isTrainingDatasetError}
-          isPending={isTrainingDatasetPending}
-          trainingDataset={trainingDataset as TTrainingDataset}
+          trainingDataset={data?.dataset}
         />
         <ModelDetailsSection
           title={MODELS_CONTENT.models.modelsDetailsCard.propertiesSectionTitle}
@@ -133,7 +119,7 @@ export const ModelDetailsPage = () => {
           ) : (
             <ModelDetailsProperties
               trainingId={data?.published_training as number}
-              datasetId={data?.dataset}
+              datasetId={data?.dataset?.id}
               baseModel={data.base_model}
             />
           )}
@@ -168,9 +154,9 @@ export const ModelDetailsPage = () => {
             modelId={data?.id as string}
             trainingId={data?.published_training as number}
             modelOwner={data?.user.username as string}
-            datasetId={data?.dataset as number}
+            datasetId={data?.dataset.id as number}
             baseModel={data?.base_model as string}
-            tmsUrl={trainingDataset.source_imagery}
+            tmsUrl={data?.dataset?.source_imagery}
           />
         </ModelDetailsSection>
       </div>

--- a/frontend/src/app/routes/start-mapping.tsx
+++ b/frontend/src/app/routes/start-mapping.tsx
@@ -11,17 +11,11 @@ import { ModelDetailsPopUp } from "@/features/start-mapping/components";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useDropdownMenu } from "@/hooks/use-dropdown-menu";
 import { useGetTMSTileJSON } from "@/features/model-creation/hooks/use-tms-tilejson";
-import { useGetTrainingDataset } from "@/features/models/hooks/use-dataset";
 import { useMapInstance } from "@/hooks/use-map-instance";
 import { useModelDetails } from "@/features/models/hooks/use-models";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { UserProfile } from "@/components/layout";
-import {
-  Feature,
-  TileJSON,
-  TModelPredictions,
-  TTrainingDataset,
-} from "@/types";
+import { Feature, TileJSON, TModelPredictions } from "@/types";
 import {
   BrandLogoWithDropDown,
   Legend,
@@ -77,24 +71,23 @@ export const StartMappingPage = () => {
 
   const {
     isError,
-    isPending,
+    isPending: modelInfoRequestIspending,
     data: modelInfo,
     error,
   } = useModelDetails(modelId as string, !!modelId);
 
-  const {
-    data: trainingDataset,
-    isPending: trainingDatasetIsPending,
-    isError: trainingDatasetIsError,
-  } = useGetTrainingDataset(modelInfo?.dataset as number, !isPending);
+  const tileJSONURL = useMemo(
+    () =>
+      modelInfo?.dataset?.source_imagery
+        ? extractTileJSONURL(modelInfo?.dataset?.source_imagery)
+        : undefined,
+    [modelInfo?.dataset?.source_imagery],
+  );
 
-  const tileJSONURL = extractTileJSONURL(trainingDataset?.source_imagery ?? "");
-
-  const {
-    data: oamTileJSON,
-    isError: oamTileJSONIsError,
-    error: oamTileJSONError,
-  } = useGetTMSTileJSON(tileJSONURL);
+  const { data: oamTileJSON, isError: oamTileJSONIsError } = useGetTMSTileJSON(
+    tileJSONURL as string,
+    !!tileJSONURL,
+  );
 
   useEffect(() => {
     if (isError) {
@@ -231,7 +224,7 @@ export const StartMappingPage = () => {
           ...modelPredictions.all,
         ],
       },
-      `all_predictions_${modelInfo.dataset}`,
+      `all_predictions_${modelInfo.dataset.id}`,
     );
     showSuccessToast(TOAST_NOTIFICATIONS.startMapping.fileDownloadSuccess);
   }, [modelPredictions, modelInfo]);
@@ -239,23 +232,22 @@ export const StartMappingPage = () => {
   const handleAcceptedFeaturesDownload = useCallback(async () => {
     geoJSONDowloader(
       { type: "FeatureCollection", features: modelPredictions.accepted },
-      `accepted_predictions_${modelInfo.dataset}`,
+      `accepted_predictions_${modelInfo.dataset.id}`,
     );
     showSuccessToast(TOAST_NOTIFICATIONS.startMapping.fileDownloadSuccess);
   }, [modelPredictions, modelInfo]);
 
   const handleFeaturesDownloadToJOSM = useCallback(
     (features: Feature[]) => {
-      if (!map || !trainingDataset?.name || !trainingDataset?.source_imagery)
-        return;
+      if (!map || !modelInfo?.dataset) return;
       openInJOSM(
-        trainingDataset.name,
-        trainingDataset.source_imagery,
+        modelInfo.dataset.name,
+        modelInfo.dataset.source_imagery,
         features,
         true,
       );
     },
-    [map, oamTileJSON, trainingDataset],
+    [map, modelInfo],
   );
 
   const handleAllFeaturesDownloadToJOSM = useCallback(() => {
@@ -319,8 +311,9 @@ export const StartMappingPage = () => {
   return (
     <>
       <Head title={START_MAPPING_PAGE_CONTENT.pageTitle(modelInfo?.name)} />
-      {/* Mobile dialog */}
+
       <div className="h-screen flex flex-col fullscreen">
+        {/* Mobile dialog */}
         <StartMappingMobileDrawer
           isOpen={isSmallViewport}
           disablePrediction={disablePrediction}
@@ -333,30 +326,26 @@ export const StartMappingPage = () => {
           updateQuery={updateQuery}
           modelDetailsPopupIsActive={showModelDetailsPopup}
           clearPredictions={clearPredictions}
-          trainingDataset={trainingDataset as TTrainingDataset}
           currentZoom={currentZoom}
           modelInfo={modelInfo}
         />
         <div className="sticky top-0 bg-white z-10 px-4 xl:px-large py-1 hidden md:block">
           {/* Model Details Popup */}
-          {modelInfo && (
-            <ModelDetailsPopUp
-              showPopup={showModelDetailsPopup}
-              handlePopup={handleModelDetailsPopup}
-              closeMobileDrawer={() => setShowModelDetailsPopup(false)}
-              anchor={popupAnchorId}
-              model={modelInfo}
-              trainingDataset={trainingDataset}
-              trainingDatasetIsPending={trainingDatasetIsPending}
-              trainingDatasetIsError={trainingDatasetIsError}
-            />
-          )}
+          <ModelDetailsPopUp
+            showPopup={showModelDetailsPopup}
+            handlePopup={handleModelDetailsPopup}
+            closeMobileDrawer={() => setShowModelDetailsPopup(false)}
+            anchor={popupAnchorId}
+            modelInfo={modelInfo}
+            modelInfoRequestIsPending={modelInfoRequestIspending}
+            modelInfoRequestIsError={isError}
+          />
           {/* Web Header */}
           <StartMappingHeader
             modelInfo={modelInfo}
-            trainingDatasetIsPending={trainingDatasetIsPending}
+            modelInfoRequestIsPending={modelInfoRequestIspending}
             modelPredictionsExist={modelPredictionsExist}
-            trainingDatasetIsError={trainingDatasetIsError}
+            modelInfoRequestIsError={isError}
             modelPredictions={modelPredictions}
             query={query}
             updateQuery={updateQuery}
@@ -368,7 +357,6 @@ export const StartMappingPage = () => {
             handleModelDetailsPopup={handleModelDetailsPopup}
             downloadOptions={downloadOptions}
             clearPredictions={clearPredictions}
-            trainingDataset={trainingDataset as TTrainingDataset}
             currentZoom={currentZoom}
           />
         </div>
@@ -402,12 +390,11 @@ export const StartMappingPage = () => {
           </div>
           {/* Map Component */}
           <StartMappingMapComponent
-            trainingDataset={trainingDataset}
+            trainingDataset={modelInfo?.dataset}
             modelPredictions={modelPredictions}
             setModelPredictions={setModelPredictions}
             oamTileJSONIsError={oamTileJSONIsError}
             oamTileJSON={oamTileJSON as TileJSON}
-            oamTileJSONError={oamTileJSONError}
             modelPredictionsExist={modelPredictionsExist}
             mapContainerRef={mapContainerRef}
             map={map}
@@ -415,6 +402,7 @@ export const StartMappingPage = () => {
             layers={mapLayers}
             tmsBounds={oamTileJSON?.bounds as LngLatBoundsLike}
             trainingId={modelInfo?.published_training}
+            modelInfoRequestIsPending={modelInfoRequestIspending}
           />
         </div>
       </div>

--- a/frontend/src/app/routes/start-mapping.tsx
+++ b/frontend/src/app/routes/start-mapping.tsx
@@ -8,7 +8,7 @@ import { FitToBounds, LayerControl, ZoomLevel } from "@/components/map";
 import { Head } from "@/components/seo";
 import { LngLatBoundsLike } from "maplibre-gl";
 import { ModelDetailsPopUp } from "@/features/start-mapping/components";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useDropdownMenu } from "@/hooks/use-dropdown-menu";
 import { useGetTMSTileJSON } from "@/features/model-creation/hooks/use-tms-tilejson";
 import { useGetTrainingDataset } from "@/features/models/hooks/use-dataset";
@@ -43,7 +43,9 @@ import {
   ACCEPTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
   ALL_MODEL_PREDICTIONS_FILL_LAYER_ID,
   ALL_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+  HOT_FAIR_MODEL_PREDICTIONS_LOCAL_STORAGE_KEY,
 } from "@/config";
+import { useLocalStorage } from "@/hooks/use-storage";
 
 export type TDownloadOptions = {
   name: string;
@@ -117,18 +119,38 @@ export const StartMappingPage = () => {
       [SEARCH_PARAMS.area]: searchParams.get(SEARCH_PARAMS.area) || 4,
     };
   });
+  const { setValue, getValue } = useLocalStorage();
 
-  // Todo - move to local storage
-  const [modelPredictions, setModelPredictions] = useState<TModelPredictions>({
-    all: [],
+  const emptyPredictionState = {
     accepted: [],
     rejected: [],
-  });
+    all: [],
+  };
+  const [modelPredictions, setModelPredictions] = useState<TModelPredictions>(
+    () => {
+      const savedPredictions = getValue(
+        HOT_FAIR_MODEL_PREDICTIONS_LOCAL_STORAGE_KEY(modelId as string),
+      );
+      return savedPredictions
+        ? JSON.parse(savedPredictions)
+        : emptyPredictionState;
+    },
+  );
 
-  const modelPredictionsExist =
-    modelPredictions.accepted.length > 0 ||
-    modelPredictions.rejected.length > 0 ||
-    modelPredictions.all.length > 0;
+  useEffect(() => {
+    setValue(
+      HOT_FAIR_MODEL_PREDICTIONS_LOCAL_STORAGE_KEY(modelId as string),
+      JSON.stringify(modelPredictions),
+    );
+  }, [modelPredictions, modelId]);
+
+  const modelPredictionsExist = useMemo(() => {
+    return (
+      modelPredictions.accepted.length > 0 ||
+      modelPredictions.rejected.length > 0 ||
+      modelPredictions.all.length > 0
+    );
+  }, [modelPredictions]);
 
   const updateQuery = useCallback(
     (newParams: TQueryParams) => {
@@ -154,47 +176,50 @@ export const StartMappingPage = () => {
 
   const popupAnchorId = "model-details";
 
-  const mapLayers = [
-    ...(modelPredictions.accepted.length > 0
-      ? [
-          {
-            value:
-              START_MAPPING_PAGE_CONTENT.map.controls.legendControl
-                .acceptedPredictions,
-            subLayers: [
-              ACCEPTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
-              ACCEPTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
-            ],
-          },
-        ]
-      : []),
-    ...(modelPredictions.rejected.length > 0
-      ? [
-          {
-            value:
-              START_MAPPING_PAGE_CONTENT.map.controls.legendControl
-                .rejectedPredictions,
-            subLayers: [
-              REJECTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
-              REJECTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
-            ],
-          },
-        ]
-      : []),
-    ...(modelPredictions.all.length > 0
-      ? [
-          {
-            value:
-              START_MAPPING_PAGE_CONTENT.map.controls.legendControl
-                .predictionResults,
-            subLayers: [
-              ALL_MODEL_PREDICTIONS_FILL_LAYER_ID,
-              ALL_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
-            ],
-          },
-        ]
-      : []),
-  ];
+  const mapLayers = useMemo(
+    () => [
+      ...(modelPredictions.accepted.length > 0
+        ? [
+            {
+              value:
+                START_MAPPING_PAGE_CONTENT.map.controls.legendControl
+                  .acceptedPredictions,
+              subLayers: [
+                ACCEPTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
+                ACCEPTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+              ],
+            },
+          ]
+        : []),
+      ...(modelPredictions.rejected.length > 0
+        ? [
+            {
+              value:
+                START_MAPPING_PAGE_CONTENT.map.controls.legendControl
+                  .rejectedPredictions,
+              subLayers: [
+                REJECTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
+                REJECTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+              ],
+            },
+          ]
+        : []),
+      ...(modelPredictions.all.length > 0
+        ? [
+            {
+              value:
+                START_MAPPING_PAGE_CONTENT.map.controls.legendControl
+                  .predictionResults,
+              subLayers: [
+                ALL_MODEL_PREDICTIONS_FILL_LAYER_ID,
+                ALL_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+              ],
+            },
+          ]
+        : []),
+    ],
+    [modelPredictions],
+  );
 
   const handleAllFeaturesDownload = useCallback(async () => {
     geoJSONDowloader(
@@ -288,11 +313,7 @@ export const StartMappingPage = () => {
   }, [setShowModelDetailsPopup]);
 
   const clearPredictions = useCallback(() => {
-    setModelPredictions({
-      accepted: [],
-      rejected: [],
-      all: [],
-    });
+    setModelPredictions(emptyPredictionState);
   }, [setModelPredictions]);
 
   return (

--- a/frontend/src/components/map/layers/open-aerial-map.tsx
+++ b/frontend/src/components/map/layers/open-aerial-map.tsx
@@ -1,8 +1,5 @@
 import { Map } from "maplibre-gl";
-import {
-  TMS_LAYER_ID,
-  TMS_SOURCE_ID,
-} from "@/config";
+import { TMS_LAYER_ID, TMS_SOURCE_ID } from "@/config";
 import { useEffect } from "react";
 
 export const OpenAerialMap = ({
@@ -29,7 +26,6 @@ export const OpenAerialMap = ({
         layout: { visibility: "visible" },
       });
     }
-
   }, [map, tileJSONURL]);
 
   return null;

--- a/frontend/src/components/map/layers/open-aerial-map.tsx
+++ b/frontend/src/components/map/layers/open-aerial-map.tsx
@@ -28,8 +28,6 @@ export const OpenAerialMap = ({
         source: TMS_SOURCE_ID,
         layout: { visibility: "visible" },
       });
-
-
     }
 
   }, [map, tileJSONURL]);

--- a/frontend/src/components/map/layers/open-aerial-map.tsx
+++ b/frontend/src/components/map/layers/open-aerial-map.tsx
@@ -1,6 +1,11 @@
 import { Map } from "maplibre-gl";
 import {
-
+  ACCEPTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
+  ACCEPTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+  ALL_MODEL_PREDICTIONS_FILL_LAYER_ID,
+  ALL_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+  REJECTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
+  REJECTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
   TMS_LAYER_ID,
   TMS_SOURCE_ID,
 } from "@/config";
@@ -29,7 +34,28 @@ export const OpenAerialMap = ({
         source: TMS_SOURCE_ID,
         layout: { visibility: "visible" },
       });
+
+
     }
+    /**
+          * Move all the layers above the OAM.
+          * This is needed incase the user reloads the page on the start mapping page
+          * and there are existing predictions in their local storage.
+          */
+
+    const layers = [
+      ACCEPTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
+      ACCEPTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+      ALL_MODEL_PREDICTIONS_FILL_LAYER_ID,
+      ALL_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+      REJECTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
+      REJECTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+    ];
+    layers.forEach((layerId) => {
+      if (map.getLayer(layerId)) {
+        map.moveLayer(TMS_LAYER_ID, layerId,);
+      }
+    });
   }, [map, tileJSONURL]);
 
   return null;

--- a/frontend/src/components/map/layers/open-aerial-map.tsx
+++ b/frontend/src/components/map/layers/open-aerial-map.tsx
@@ -1,5 +1,9 @@
 import { Map } from "maplibre-gl";
-import { TMS_LAYER_ID, TMS_SOURCE_ID } from "@/config";
+import {
+
+  TMS_LAYER_ID,
+  TMS_SOURCE_ID,
+} from "@/config";
 import { useEffect } from "react";
 
 export const OpenAerialMap = ({
@@ -26,7 +30,7 @@ export const OpenAerialMap = ({
         layout: { visibility: "visible" },
       });
     }
-  }, [map]);
+  }, [map, tileJSONURL]);
 
   return null;
 };

--- a/frontend/src/components/map/layers/open-aerial-map.tsx
+++ b/frontend/src/components/map/layers/open-aerial-map.tsx
@@ -1,6 +1,6 @@
 import { Map } from "maplibre-gl";
 import { TMS_LAYER_ID, TMS_SOURCE_ID } from "@/config";
-import { useMapLayers } from "@/hooks/use-map-layer";
+import { useEffect } from "react";
 
 export const OpenAerialMap = ({
   tileJSONURL,
@@ -9,26 +9,24 @@ export const OpenAerialMap = ({
   tileJSONURL?: string;
   map: Map | null;
 }) => {
-  useMapLayers(
-    [
-      {
+  useEffect(() => {
+    if (!map) return;
+    if (!map.getSource(TMS_SOURCE_ID)) {
+      map.addSource(TMS_SOURCE_ID, {
+        type: "raster",
+        url: tileJSONURL,
+        tileSize: 256,
+      });
+    }
+    if (!map.getLayer(TMS_LAYER_ID)) {
+      map.addLayer({
         id: TMS_LAYER_ID,
         type: "raster",
         source: TMS_SOURCE_ID,
         layout: { visibility: "visible" },
-      },
-    ],
-    [
-      {
-        id: TMS_SOURCE_ID,
-        spec: {
-          type: "raster",
-          url: tileJSONURL,
-          tileSize: 256,
-        },
-      },
-    ],
-    map,
-  );
+      });
+    }
+  }, [map]);
+
   return null;
 };

--- a/frontend/src/config/index.ts
+++ b/frontend/src/config/index.ts
@@ -126,10 +126,11 @@ export const HOT_FAIR_BANNER_LOCAL_STORAGE_KEY: string =
   "__hot_fair_banner_closed";
 
 /**
- * The key used to store the model predictions in the session storage for the application.
+ * The key used to store the predictions for the specific model in the users local storage.
  */
-export const HOT_FAIR_MODEL_PREDICTIONS_SESSION_STORAGE_KEY: string =
-  "__hot_fair_model_predictions";
+export const HOT_FAIR_MODEL_PREDICTIONS_LOCAL_STORAGE_KEY = (
+  modelId: string,
+): string => `__hot_fair_model_predictions_for_model_${modelId}`;
 
 // ==============================================================================================================================
 // Training Area Configurations

--- a/frontend/src/config/index.ts
+++ b/frontend/src/config/index.ts
@@ -191,6 +191,8 @@ export const MAX_ACCEPTABLE_POLYGON_IN_TRAINING_AREA_GEOJSON_FILE: number =
 
 /**
  * The maximum zoom level for the map.
+ * Model predictions require a max zoom of 22.
+ * 21 is used here because 1 is already added to the 'currentZoom' in the useMapInstance() hook.
  */
 export const MAX_ZOOM_LEVEL: number = parseIntEnv(ENVS.MAX_ZOOM_LEVEL, 21);
 
@@ -379,7 +381,7 @@ const REFRESH_BUFFER_MS: number = 1000;
  */
 export const KPI_STATS_CACHE_TIME_MS: number =
   parseIntEnv(ENVS.KPI_STATS_CACHE_TIME, DEFAULT_KPI_STATS_CACHE_TIME_SECONDS) *
-    1000 +
+  1000 +
   REFRESH_BUFFER_MS;
 
 // ==============================================================================================================================

--- a/frontend/src/config/index.ts
+++ b/frontend/src/config/index.ts
@@ -192,7 +192,7 @@ export const MAX_ACCEPTABLE_POLYGON_IN_TRAINING_AREA_GEOJSON_FILE: number =
 /**
  * The maximum zoom level for the map.
  */
-export const MAX_ZOOM_LEVEL: number = parseIntEnv(ENVS.MAX_ZOOM_LEVEL, 22);
+export const MAX_ZOOM_LEVEL: number = parseIntEnv(ENVS.MAX_ZOOM_LEVEL, 21);
 
 /**
  * The minimum zoom level for the map before the prediction components can be activated.

--- a/frontend/src/features/model-creation/components/training-area/open-area-map.tsx
+++ b/frontend/src/features/model-creation/components/training-area/open-area-map.tsx
@@ -22,7 +22,10 @@ const OpenAerialMap = ({
 }) => {
   const { handleChange } = useModelsContext();
 
-  const { isPending, data, isError } = useGetTMSTileJSON(tileJSONURL);
+  const { isPending, data, isError } = useGetTMSTileJSON(
+    tileJSONURL,
+    !!trainingDatasetId,
+  );
 
   const { data: trainingDataset, isError: trainingDatasetFetchError } =
     useGetTrainingDataset(trainingDatasetId);

--- a/frontend/src/features/model-creation/hooks/use-models.ts
+++ b/frontend/src/features/model-creation/hooks/use-models.ts
@@ -58,7 +58,7 @@ export const useUpdateModel = ({
   mutationConfig,
   modelId,
 }: useUpdateModelOptions) => {
-  const { refetch: refetchModelDetails } = useModelDetails(modelId);
+  const { refetch: refetchModelDetails } = useModelDetails(modelId, true);
   const queryClient = useQueryClient();
   const { onSuccess, ...restConfig } = mutationConfig || {};
 

--- a/frontend/src/features/model-creation/hooks/use-tms-tilejson.ts
+++ b/frontend/src/features/model-creation/hooks/use-tms-tilejson.ts
@@ -1,8 +1,9 @@
 import { getTMSTileJSONQueryOptions } from "@/features/model-creation/api/factory";
 import { useQuery } from "@tanstack/react-query";
 
-export const useGetTMSTileJSON = (url: string) => {
+export const useGetTMSTileJSON = (url: string, enabled: boolean) => {
   return useQuery({
     ...getTMSTileJSONQueryOptions(url),
+    enabled: enabled,
   });
 };

--- a/frontend/src/features/models/api/factory.ts
+++ b/frontend/src/features/models/api/factory.ts
@@ -60,12 +60,14 @@ export const getModelsQueryOptions = ({
 export const getModelDetailsQueryOptions = (
   id: string,
   refetchInterval: boolean | number,
+  enabled: boolean,
 ) => {
   return queryOptions({
     queryKey: [queryKeys.MODEL_DETAILS(id)],
     queryFn: () => getModelDetails(id),
     //@ts-expect-error bad type definition
     refetchInterval: refetchInterval,
+    enabled: enabled,
   });
 };
 

--- a/frontend/src/features/models/api/update-trainings.ts
+++ b/frontend/src/features/models/api/update-trainings.ts
@@ -17,7 +17,10 @@ export const useUpdateTraining = ({
   mutationConfig,
   modelId,
 }: UseUpdateTrainingOptions) => {
-  const { refetch: refetchModelDetails } = useModelDetails(String(modelId));
+  const { refetch: refetchModelDetails } = useModelDetails(
+    String(modelId),
+    true,
+  );
   const { refetch: refetchTrainingHistory } = useTrainingHistory(
     String(modelId),
     0,

--- a/frontend/src/features/models/components/dialogs/training-settings-dialog.tsx
+++ b/frontend/src/features/models/components/dialogs/training-settings-dialog.tsx
@@ -24,7 +24,7 @@ const ModelTrainingSettingsDialog: React.FC<ModelEnhancementDialogProps> = ({
   closeDialog,
   modelId,
 }) => {
-  const { data, isPending, isError } = useModelDetails(modelId);
+  const { data, isPending, isError } = useModelDetails(modelId, true);
 
   const { handleChange, formData, createNewTrainingRequestMutation } =
     useModelsContext();

--- a/frontend/src/features/models/components/model-details-info.tsx
+++ b/frontend/src/features/models/components/model-details-info.tsx
@@ -19,15 +19,11 @@ const ModelDetailsInfo = ({
   openModelFilesDialog,
   openTrainingAreaDrawer,
   trainingDataset,
-  isError,
-  isPending,
 }: {
   data: TModelDetails;
   openModelFilesDialog: () => void;
   openTrainingAreaDrawer: () => void;
   trainingDataset: TTrainingDataset;
-  isError: boolean;
-  isPending: boolean;
 }) => {
   const { isOpened, openDialog, closeDialog } = useDialog();
   const { user, isAuthenticated } = useAuth();
@@ -105,21 +101,15 @@ const ModelDetailsInfo = ({
               <span className="text-gray">
                 {MODELS_CONTENT.models.modelsDetailsCard.datasetName}
               </span>
-              {isPending ? (
-                <p className="h-6 ml-2 w-20 animate-pulse bg-light-gray"></p>
-              ) : isError ? (
-                <span>Error retrieving dataset info</span>
-              ) : (
-                <p title={trainingDataset?.name}>
-                  {truncateString(trainingDataset?.name, 40)}
-                </p>
-              )}
+              <p title={trainingDataset?.name}>
+                {truncateString(trainingDataset?.name, 40)}
+              </p>
             </div>
             <div className="text-dark text-body-2 flex gap-x-1">
               <span className="text-gray">
                 {MODELS_CONTENT.models.modelsDetailsCard.datasetId}
               </span>
-              <p>{data?.dataset}</p>
+              <p>{data?.dataset.id}</p>
             </div>
             <ModelFilesButton
               openModelFilesDialog={openModelFilesDialog}

--- a/frontend/src/features/models/hooks/use-models.ts
+++ b/frontend/src/features/models/hooks/use-models.ts
@@ -52,17 +52,16 @@ export const useModels = ({
 
 export const useModelDetails = (
   id: string,
-  enabled: boolean = true,
+  enabled: boolean = false,
   refetchInterval: boolean | number = false,
 ) => {
   return useQuery({
-    ...getModelDetailsQueryOptions(id, refetchInterval),
+    ...getModelDetailsQueryOptions(id, refetchInterval, enabled),
     retry: (_, error) => {
       // When a model is not found, don't retry.
       //@ts-expect-error bad type definition
       return error.response?.status !== 404;
     },
-    enabled: enabled,
   });
 };
 

--- a/frontend/src/features/start-mapping/components/header.tsx
+++ b/frontend/src/features/start-mapping/components/header.tsx
@@ -11,7 +11,7 @@ import { ModelPredictionsTracker } from "@/features/start-mapping/components/mod
 import { ModelSettings } from "@/features/start-mapping/components/model-settings";
 import { SkeletonWrapper } from "@/components/ui/skeleton";
 import { TDownloadOptions, TQueryParams } from "@/app/routes/start-mapping";
-import { TModel, TModelPredictions, TTrainingDataset } from "@/types";
+import { TModelDetails, TModelPredictions } from "@/types";
 import { ToolTip } from "@/components/ui/tooltip";
 import { useDropdownMenu } from "@/hooks/use-dropdown-menu";
 import { UserProfile } from "@/components/layout";
@@ -21,8 +21,8 @@ const StartMappingHeader = ({
   modelInfo,
   modelPredictions,
   modelPredictionsExist,
-  trainingDatasetIsPending,
-  trainingDatasetIsError,
+  modelInfoRequestIsPending,
+  modelInfoRequestIsError,
   query,
   updateQuery,
   setModelPredictions,
@@ -33,13 +33,12 @@ const StartMappingHeader = ({
   modelDetailsPopupIsActive,
   downloadOptions,
   clearPredictions,
-  trainingDataset,
   currentZoom,
 }: {
   modelPredictionsExist: boolean;
-  trainingDatasetIsPending: boolean;
-  trainingDatasetIsError: boolean;
-  modelInfo: TModel;
+  modelInfoRequestIsPending: boolean;
+  modelInfoRequestIsError: boolean;
+  modelInfo: TModelDetails;
   modelPredictions: TModelPredictions;
   query: TQueryParams;
   updateQuery: (newParams: TQueryParams) => void;
@@ -51,7 +50,6 @@ const StartMappingHeader = ({
   modelDetailsPopupIsActive: boolean;
   downloadOptions: TDownloadOptions;
   clearPredictions: () => void;
-  trainingDataset: TTrainingDataset;
   currentZoom: number;
 }) => {
   const { onDropdownHide, onDropdownShow, dropdownIsOpened } =
@@ -65,7 +63,7 @@ const StartMappingHeader = ({
 
   return (
     <SkeletonWrapper
-      showSkeleton={trainingDatasetIsPending || trainingDatasetIsError}
+      showSkeleton={modelInfoRequestIsPending || modelInfoRequestIsError}
       skeletonClassName="h-10"
     >
       <div className="flex items-center justify-between">
@@ -138,7 +136,6 @@ const StartMappingHeader = ({
             map={map}
             disablePrediction={disablePrediction}
             query={query}
-            trainingDataset={trainingDataset}
             currentZoom={currentZoom}
             modelInfo={modelInfo}
           />

--- a/frontend/src/features/start-mapping/components/map/layers/accepted-prediction-layer.tsx
+++ b/frontend/src/features/start-mapping/components/map/layers/accepted-prediction-layer.tsx
@@ -1,0 +1,65 @@
+import {
+  ACCEPTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
+  ACCEPTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+  ACCEPTED_MODEL_PREDICTIONS_SOURCE_ID,
+} from "@/config";
+import { Feature, GeoJSONType } from "@/types";
+import { GeoJSONSource, Map } from "maplibre-gl";
+import { useEffect, useMemo } from "react";
+
+export const AcceptedPredictionsLayer = ({
+  map,
+  features,
+}: {
+  map: Map | null;
+  features: Feature[];
+}) => {
+  const geoJsonData = useMemo(
+    () => ({
+      type: "FeatureCollection",
+      features: features,
+    }),
+    [features],
+  );
+
+  useEffect(() => {
+    if (!map) return;
+    map.addSource(ACCEPTED_MODEL_PREDICTIONS_SOURCE_ID, {
+      type: "geojson",
+      data: { type: "FeatureCollection", features: [] },
+    });
+    map.addLayer({
+      id: ACCEPTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
+      type: "fill",
+      source: ACCEPTED_MODEL_PREDICTIONS_SOURCE_ID,
+      paint: {
+        "fill-color": "#23C16B",
+        "fill-opacity": 0.2,
+      },
+      layout: { visibility: "visible" },
+    });
+
+    map.addLayer({
+      id: ACCEPTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+      type: "line",
+      source: ACCEPTED_MODEL_PREDICTIONS_SOURCE_ID,
+      paint: {
+        "line-color": "#23C16B",
+        "line-width": 2,
+      },
+      layout: { visibility: "visible" },
+    });
+  }, [map]);
+
+  useEffect(() => {
+    if (!map || !features) return;
+    const source = map.getSource(
+      ACCEPTED_MODEL_PREDICTIONS_SOURCE_ID,
+    ) as GeoJSONSource;
+    if (source) {
+      source.setData(geoJsonData as GeoJSONType);
+    }
+  }, [map, geoJsonData]);
+
+  return null;
+};

--- a/frontend/src/features/start-mapping/components/map/layers/accepted-prediction-layer.tsx
+++ b/frontend/src/features/start-mapping/components/map/layers/accepted-prediction-layer.tsx
@@ -24,31 +24,36 @@ export const AcceptedPredictionsLayer = ({
 
   useEffect(() => {
     if (!map) return;
-    map.addSource(ACCEPTED_MODEL_PREDICTIONS_SOURCE_ID, {
-      type: "geojson",
-      data: { type: "FeatureCollection", features: [] },
-    });
-    map.addLayer({
-      id: ACCEPTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
-      type: "fill",
-      source: ACCEPTED_MODEL_PREDICTIONS_SOURCE_ID,
-      paint: {
-        "fill-color": "#23C16B",
-        "fill-opacity": 0.2,
-      },
-      layout: { visibility: "visible" },
-    });
-
-    map.addLayer({
-      id: ACCEPTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
-      type: "line",
-      source: ACCEPTED_MODEL_PREDICTIONS_SOURCE_ID,
-      paint: {
-        "line-color": "#23C16B",
-        "line-width": 2,
-      },
-      layout: { visibility: "visible" },
-    });
+    if (!map.getSource(ACCEPTED_MODEL_PREDICTIONS_SOURCE_ID)) {
+      map.addSource(ACCEPTED_MODEL_PREDICTIONS_SOURCE_ID, {
+        type: "geojson",
+        data: { type: "FeatureCollection", features: [] },
+      });
+    }
+    if (!map.getLayer(ACCEPTED_MODEL_PREDICTIONS_FILL_LAYER_ID)) {
+      map.addLayer({
+        id: ACCEPTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
+        type: "fill",
+        source: ACCEPTED_MODEL_PREDICTIONS_SOURCE_ID,
+        paint: {
+          "fill-color": "#23C16B",
+          "fill-opacity": 0.2,
+        },
+        layout: { visibility: "visible" },
+      });
+    }
+    if (!map.getLayer(ACCEPTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID)) {
+      map.addLayer({
+        id: ACCEPTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+        type: "line",
+        source: ACCEPTED_MODEL_PREDICTIONS_SOURCE_ID,
+        paint: {
+          "line-color": "#23C16B",
+          "line-width": 2,
+        },
+        layout: { visibility: "visible" },
+      });
+    }
   }, [map]);
 
   useEffect(() => {

--- a/frontend/src/features/start-mapping/components/map/layers/all-prediction-layer.tsx
+++ b/frontend/src/features/start-mapping/components/map/layers/all-prediction-layer.tsx
@@ -26,32 +26,38 @@ export const AllPredictionsLayer = ({
 
   useEffect(() => {
     if (!map) return;
+    if (!map.getSource(ALL_MODEL_PREDICTIONS_SOURCE_ID)) {
+      map.addSource(ALL_MODEL_PREDICTIONS_SOURCE_ID, {
+        type: "geojson",
+        data: { type: "FeatureCollection", features: [] },
+      });
+    }
 
-    map.addSource(ALL_MODEL_PREDICTIONS_SOURCE_ID, {
-      type: "geojson",
-      data: { type: "FeatureCollection", features: [] },
-    });
-    map.addLayer({
-      id: ALL_MODEL_PREDICTIONS_FILL_LAYER_ID,
-      type: "fill",
-      source: ALL_MODEL_PREDICTIONS_SOURCE_ID,
-      paint: {
-        "fill-color": "#A243DC",
-        "fill-opacity": 0.2,
-      },
-      layout: { visibility: "visible" },
-    });
+    if (!map.getLayer(ALL_MODEL_PREDICTIONS_FILL_LAYER_ID)) {
+      map.addLayer({
+        id: ALL_MODEL_PREDICTIONS_FILL_LAYER_ID,
+        type: "fill",
+        source: ALL_MODEL_PREDICTIONS_SOURCE_ID,
+        paint: {
+          "fill-color": "#A243DC",
+          "fill-opacity": 0.2,
+        },
+        layout: { visibility: "visible" },
+      });
+    }
 
-    map.addLayer({
-      id: ALL_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
-      type: "line",
-      source: ALL_MODEL_PREDICTIONS_SOURCE_ID,
-      paint: {
-        "line-color": "#A243DC",
-        "line-width": 2,
-      },
-      layout: { visibility: "visible" },
-    });
+    if (!map.getLayer(ALL_MODEL_PREDICTIONS_OUTLINE_LAYER_ID)) {
+      map.addLayer({
+        id: ALL_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+        type: "line",
+        source: ALL_MODEL_PREDICTIONS_SOURCE_ID,
+        paint: {
+          "line-color": "#A243DC",
+          "line-width": 2,
+        },
+        layout: { visibility: "visible" },
+      });
+    }
   }, [map]);
 
   useEffect(() => {

--- a/frontend/src/features/start-mapping/components/map/layers/all-prediction-layer.tsx
+++ b/frontend/src/features/start-mapping/components/map/layers/all-prediction-layer.tsx
@@ -1,0 +1,68 @@
+import {
+  ALL_MODEL_PREDICTIONS_FILL_LAYER_ID,
+  ALL_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+  ALL_MODEL_PREDICTIONS_SOURCE_ID,
+} from "@/config";
+import { Feature, GeoJSONType } from "@/types";
+import { GeoJSONSource, Map } from "maplibre-gl";
+import { useEffect, useMemo } from "react";
+
+type AllPredictionsLayerProps = {
+  map: Map | null;
+  features: Feature[];
+};
+
+export const AllPredictionsLayer = ({
+  map,
+  features,
+}: AllPredictionsLayerProps) => {
+  const geoJsonData = useMemo(
+    () => ({
+      type: "FeatureCollection",
+      features: features,
+    }),
+    [features],
+  );
+
+  useEffect(() => {
+    if (!map) return;
+
+    map.addSource(ALL_MODEL_PREDICTIONS_SOURCE_ID, {
+      type: "geojson",
+      data: { type: "FeatureCollection", features: [] },
+    });
+    map.addLayer({
+      id: ALL_MODEL_PREDICTIONS_FILL_LAYER_ID,
+      type: "fill",
+      source: ALL_MODEL_PREDICTIONS_SOURCE_ID,
+      paint: {
+        "fill-color": "#A243DC",
+        "fill-opacity": 0.2,
+      },
+      layout: { visibility: "visible" },
+    });
+
+    map.addLayer({
+      id: ALL_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+      type: "line",
+      source: ALL_MODEL_PREDICTIONS_SOURCE_ID,
+      paint: {
+        "line-color": "#A243DC",
+        "line-width": 2,
+      },
+      layout: { visibility: "visible" },
+    });
+  }, [map]);
+
+  useEffect(() => {
+    if (!map || !features) return;
+    const source = map.getSource(
+      ALL_MODEL_PREDICTIONS_SOURCE_ID,
+    ) as GeoJSONSource;
+    if (source) {
+      source.setData(geoJsonData as GeoJSONType);
+    }
+  }, [map, geoJsonData]);
+
+  return null;
+};

--- a/frontend/src/features/start-mapping/components/map/layers/index.ts
+++ b/frontend/src/features/start-mapping/components/map/layers/index.ts
@@ -1,0 +1,3 @@
+export { AcceptedPredictionsLayer } from "./accepted-prediction-layer";
+export { RejectedPredictionsLayer } from "./rejected-prediction-layer";
+export { AllPredictionsLayer } from "./all-prediction-layer";

--- a/frontend/src/features/start-mapping/components/map/layers/rejected-prediction-layer.tsx
+++ b/frontend/src/features/start-mapping/components/map/layers/rejected-prediction-layer.tsx
@@ -25,32 +25,37 @@ export const RejectedPredictionsLayer = ({
   useEffect(() => {
     if (!map) return;
 
-    map.addSource(REJECTED_MODEL_PREDICTIONS_SOURCE_ID, {
-      type: "geojson",
-      data: { type: "FeatureCollection", features: [] },
-    });
+    if (!map.getSource(REJECTED_MODEL_PREDICTIONS_SOURCE_ID)) {
+      map.addSource(REJECTED_MODEL_PREDICTIONS_SOURCE_ID, {
+        type: "geojson",
+        data: { type: "FeatureCollection", features: [] },
+      });
+    }
 
-    map.addLayer({
-      id: REJECTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
-      type: "fill",
-      source: REJECTED_MODEL_PREDICTIONS_SOURCE_ID,
-      paint: {
-        "fill-color": "#D63F40",
-        "fill-opacity": 0.2,
-      },
-      layout: { visibility: "visible" },
-    });
-
-    map.addLayer({
-      id: REJECTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
-      type: "line",
-      source: REJECTED_MODEL_PREDICTIONS_SOURCE_ID,
-      paint: {
-        "line-color": "#D63F40",
-        "line-width": 2,
-      },
-      layout: { visibility: "visible" },
-    });
+    if (!map.getLayer(REJECTED_MODEL_PREDICTIONS_FILL_LAYER_ID)) {
+      map.addLayer({
+        id: REJECTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
+        type: "fill",
+        source: REJECTED_MODEL_PREDICTIONS_SOURCE_ID,
+        paint: {
+          "fill-color": "#D63F40",
+          "fill-opacity": 0.2,
+        },
+        layout: { visibility: "visible" },
+      });
+    }
+    if (!map.getLayer(REJECTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID)) {
+      map.addLayer({
+        id: REJECTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+        type: "line",
+        source: REJECTED_MODEL_PREDICTIONS_SOURCE_ID,
+        paint: {
+          "line-color": "#D63F40",
+          "line-width": 2,
+        },
+        layout: { visibility: "visible" },
+      });
+    }
   }, [map]);
 
   useEffect(() => {

--- a/frontend/src/features/start-mapping/components/map/layers/rejected-prediction-layer.tsx
+++ b/frontend/src/features/start-mapping/components/map/layers/rejected-prediction-layer.tsx
@@ -1,0 +1,67 @@
+import {
+  REJECTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
+  REJECTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+  REJECTED_MODEL_PREDICTIONS_SOURCE_ID,
+} from "@/config";
+import { Feature, GeoJSONType } from "@/types";
+import { GeoJSONSource, Map } from "maplibre-gl";
+import { useEffect, useMemo } from "react";
+
+export const RejectedPredictionsLayer = ({
+  map,
+  features,
+}: {
+  map: Map | null;
+  features: Feature[];
+}) => {
+  const geoJsonData = useMemo(
+    () => ({
+      type: "FeatureCollection",
+      features: features,
+    }),
+    [features],
+  );
+
+  useEffect(() => {
+    if (!map) return;
+
+    map.addSource(REJECTED_MODEL_PREDICTIONS_SOURCE_ID, {
+      type: "geojson",
+      data: { type: "FeatureCollection", features: [] },
+    });
+
+    map.addLayer({
+      id: REJECTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
+      type: "fill",
+      source: REJECTED_MODEL_PREDICTIONS_SOURCE_ID,
+      paint: {
+        "fill-color": "#D63F40",
+        "fill-opacity": 0.2,
+      },
+      layout: { visibility: "visible" },
+    });
+
+    map.addLayer({
+      id: REJECTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+      type: "line",
+      source: REJECTED_MODEL_PREDICTIONS_SOURCE_ID,
+      paint: {
+        "line-color": "#D63F40",
+        "line-width": 2,
+      },
+      layout: { visibility: "visible" },
+    });
+  }, [map]);
+
+  useEffect(() => {
+    if (!map || !features) return;
+    const source = map.getSource(
+      REJECTED_MODEL_PREDICTIONS_SOURCE_ID,
+    ) as GeoJSONSource;
+    if (source) {
+      source.setData(geoJsonData as GeoJSONType);
+    }
+  }, [map, features]);
+
+  return null;
+};

--- a/frontend/src/features/start-mapping/components/map/map.tsx
+++ b/frontend/src/features/start-mapping/components/map/map.tsx
@@ -2,23 +2,20 @@ import PredictedFeatureActionPopup from "@/features/start-mapping/components/fea
 import useScreenSize from "@/hooks/use-screen-size";
 import { ControlsPosition } from "@/enums";
 import { extractTileJSONURL, showErrorToast } from "@/utils";
-import { GeoJSONSource, LngLatBoundsLike, Map } from "maplibre-gl";
+import { LngLatBoundsLike, Map } from "maplibre-gl";
 import { Legend } from "@/features/start-mapping/components";
 import { MapComponent, MapCursorToolTip } from "@/components/map";
 import { TOAST_NOTIFICATIONS } from "@/constants";
-import { useMapLayers } from "@/hooks/use-map-layer";
 import { useToolTipVisibility } from "@/hooks/use-tooltip-visibility";
 import {
   Dispatch,
   RefObject,
   SetStateAction,
-  useCallback,
   useEffect,
   useState,
 } from "react";
 
 import {
-  GeoJSONType,
   TileJSON,
   TModelPredictionFeature,
   TModelPredictions,
@@ -26,17 +23,15 @@ import {
 } from "@/types";
 import {
   ACCEPTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
-  ACCEPTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
-  ACCEPTED_MODEL_PREDICTIONS_SOURCE_ID,
   ALL_MODEL_PREDICTIONS_FILL_LAYER_ID,
-  ALL_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
-  ALL_MODEL_PREDICTIONS_SOURCE_ID,
   MIN_ZOOM_LEVEL_FOR_START_MAPPING_PREDICTION,
   MINIMUM_ZOOM_LEVEL_INSTRUCTION_FOR_PREDICTION,
   REJECTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
-  REJECTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
-  REJECTED_MODEL_PREDICTIONS_SOURCE_ID,
 } from "@/config";
+import bbox from "@turf/bbox";
+import { AcceptedPredictionsLayer } from "./layers/accepted-prediction-layer";
+import { RejectedPredictionsLayer } from "./layers/rejected-prediction-layer";
+import { AllPredictionsLayer } from "./layers/all-prediction-layer";
 
 export const StartMappingMapComponent = ({
   trainingDataset,
@@ -94,142 +89,20 @@ export const StartMappingMapComponent = ({
 
   useEffect(() => {
     if (!map || !tmsBounds || oamTileJSONIsError) return;
-    map.fitBounds(tmsBounds);
-  }, [map, tmsBounds, oamTileJSONIsError, oamTileJSON]);
 
-  // Add the map layers
-  useMapLayers(
-    // layers
-    [
-      // accepted
-      {
-        id: ACCEPTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
-        type: "fill",
-        source: ACCEPTED_MODEL_PREDICTIONS_SOURCE_ID,
-        paint: {
-          "fill-color": "#23C16B",
-          "fill-opacity": 0.2,
-        },
-        layout: { visibility: "visible" },
-      },
-      {
-        id: ACCEPTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
-        type: "line",
-        source: ACCEPTED_MODEL_PREDICTIONS_SOURCE_ID,
-        paint: {
-          "line-color": "#23C16B",
-          "line-width": 2,
-        },
-        layout: { visibility: "visible" },
-      },
-      // rejected
-      {
-        id: REJECTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
-        type: "fill",
-        source: REJECTED_MODEL_PREDICTIONS_SOURCE_ID,
-        paint: {
-          "fill-color": "#D63F40",
-          "fill-opacity": 0.2,
-        },
-        layout: { visibility: "visible" },
-      },
-      {
-        id: REJECTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
-        type: "line",
-        source: REJECTED_MODEL_PREDICTIONS_SOURCE_ID,
-        paint: {
-          "line-color": "#D63F40",
-          "line-width": 2,
-        },
-        layout: { visibility: "visible" },
-      },
-      // all
-      {
-        id: ALL_MODEL_PREDICTIONS_FILL_LAYER_ID,
-        type: "fill",
-        source: ALL_MODEL_PREDICTIONS_SOURCE_ID,
-        paint: {
-          "fill-color": "#A243DC",
-          "fill-opacity": 0.2,
-        },
-        layout: { visibility: "visible" },
-      },
-      {
-        id: ALL_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
-        type: "line",
-        source: ALL_MODEL_PREDICTIONS_SOURCE_ID,
-        paint: {
-          "line-color": "#A243DC",
-          "line-width": 2,
-        },
-        layout: { visibility: "visible" },
-      },
-    ],
-    // sources
-    [
-      {
-        id: ACCEPTED_MODEL_PREDICTIONS_SOURCE_ID,
-        spec: {
-          type: "geojson",
-          data: { type: "FeatureCollection", features: [] },
-        },
-      },
-      {
-        id: REJECTED_MODEL_PREDICTIONS_SOURCE_ID,
-        spec: {
-          type: "geojson",
-          data: { type: "FeatureCollection", features: [] },
-        },
-      },
-      {
-        id: ALL_MODEL_PREDICTIONS_SOURCE_ID,
-        spec: {
-          type: "geojson",
-          data: { type: "FeatureCollection", features: [] },
-        },
-      },
-    ],
-    map,
-  );
-
-  const updateLayers = useCallback(() => {
-    if (map) {
-      if (map?.getSource(ACCEPTED_MODEL_PREDICTIONS_SOURCE_ID)) {
-        const source = map.getSource(
-          ACCEPTED_MODEL_PREDICTIONS_SOURCE_ID,
-        ) as GeoJSONSource;
-        source.setData({
-          type: "FeatureCollection",
-          features: modelPredictions.accepted,
-        } as GeoJSONType);
-      }
-
-      if (map?.getSource(REJECTED_MODEL_PREDICTIONS_SOURCE_ID)) {
-        const source = map.getSource(
-          REJECTED_MODEL_PREDICTIONS_SOURCE_ID,
-        ) as GeoJSONSource;
-        source.setData({
-          type: "FeatureCollection",
-          features: modelPredictions.rejected,
-        } as GeoJSONType);
-      }
-
-      if (map?.getSource(ALL_MODEL_PREDICTIONS_SOURCE_ID)) {
-        const source = map.getSource(
-          ALL_MODEL_PREDICTIONS_SOURCE_ID,
-        ) as GeoJSONSource;
-        source.setData({
+    // if there are predictions that the user hasn't interacted with, zoom to them.
+    if (modelPredictions.all.length > 0) {
+      // get the bbox of the features with turf.
+      map.fitBounds(
+        bbox({
           type: "FeatureCollection",
           features: modelPredictions.all,
-        } as GeoJSONType);
-      }
+        }) as LngLatBoundsLike,
+      );
+    } else {
+      map.fitBounds(tmsBounds);
     }
-  }, [map, modelPredictions]);
-
-  useEffect(() => {
-    if (!map) return;
-    updateLayers();
-  }, [map, updateLayers, modelPredictions]);
+  }, [map, tmsBounds, oamTileJSONIsError, oamTileJSON]);
 
   useEffect(() => {
     if (!map) return;
@@ -287,6 +160,15 @@ export const StartMappingMapComponent = ({
       basemaps
       showCurrentZoom={!isSmallViewport}
     >
+      <AcceptedPredictionsLayer
+        map={map}
+        features={modelPredictions.accepted}
+      />
+      <RejectedPredictionsLayer
+        map={map}
+        features={modelPredictions.rejected}
+      />
+      <AllPredictionsLayer map={map} features={modelPredictions.all} />
       {showPopup && (
         <PredictedFeatureActionPopup
           event={selectedEvent}

--- a/frontend/src/features/start-mapping/components/map/map.tsx
+++ b/frontend/src/features/start-mapping/components/map/map.tsx
@@ -29,9 +29,11 @@ import {
   REJECTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
 } from "@/config";
 import bbox from "@turf/bbox";
-import { AcceptedPredictionsLayer } from "./layers/accepted-prediction-layer";
-import { RejectedPredictionsLayer } from "./layers/rejected-prediction-layer";
-import { AllPredictionsLayer } from "./layers/all-prediction-layer";
+import {
+  AcceptedPredictionsLayer,
+  RejectedPredictionsLayer,
+  AllPredictionsLayer,
+} from "@/features/start-mapping/components/map/layers";
 
 export const StartMappingMapComponent = ({
   trainingDataset,
@@ -39,7 +41,6 @@ export const StartMappingMapComponent = ({
   setModelPredictions,
   oamTileJSONIsError,
   oamTileJSON,
-  oamTileJSONError,
   modelPredictionsExist,
   map,
   mapContainerRef,
@@ -47,10 +48,12 @@ export const StartMappingMapComponent = ({
   layers,
   tmsBounds,
   trainingId,
+  modelInfoRequestIsPending,
 }: {
   trainingId: number;
   trainingDataset?: TTrainingDataset;
   modelPredictions: TModelPredictions;
+
   setModelPredictions: Dispatch<
     SetStateAction<{
       all: TModelPredictionFeature[];
@@ -61,7 +64,6 @@ export const StartMappingMapComponent = ({
 
   oamTileJSONIsError: boolean;
   oamTileJSON: TileJSON;
-  oamTileJSONError: any;
   modelPredictionsExist: boolean;
   map: Map | null;
   currentZoom: number;
@@ -71,6 +73,7 @@ export const StartMappingMapComponent = ({
     subLayers: string[];
   }[];
   tmsBounds: LngLatBoundsLike;
+  modelInfoRequestIsPending: boolean;
 }) => {
   const tileJSONURL = extractTileJSONURL(trainingDataset?.source_imagery ?? "");
   const [showPopup, setShowPopup] = useState<boolean>(false);
@@ -85,10 +88,11 @@ export const StartMappingMapComponent = ({
   useEffect(() => {
     if (!oamTileJSONIsError) return;
     showErrorToast(undefined, TOAST_NOTIFICATIONS.trainingDataset.error);
-  }, [oamTileJSONIsError, oamTileJSONError]);
+  }, [oamTileJSONIsError]);
 
   useEffect(() => {
-    if (!map || !tmsBounds || oamTileJSONIsError) return;
+    if (!map || !tmsBounds || oamTileJSONIsError || modelInfoRequestIsPending)
+      return;
 
     // if there are predictions that the user hasn't interacted with, zoom to them.
     if (modelPredictions.all.length > 0) {
@@ -102,17 +106,21 @@ export const StartMappingMapComponent = ({
     } else {
       map.fitBounds(tmsBounds);
     }
-  }, [map, tmsBounds, oamTileJSONIsError, oamTileJSON]);
+  }, [
+    map,
+    tmsBounds,
+    oamTileJSONIsError,
+    oamTileJSON,
+    modelInfoRequestIsPending,
+  ]);
 
   useEffect(() => {
     if (!map) return;
-
     const layerIds = [
       ALL_MODEL_PREDICTIONS_FILL_LAYER_ID,
       ACCEPTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
       REJECTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
     ];
-
     const handleMouseEnter = () => {
       map.getCanvas().style.cursor = "pointer";
     };
@@ -143,10 +151,10 @@ export const StartMappingMapComponent = ({
 
   const showTooltip =
     currentZoom < MIN_ZOOM_LEVEL_FOR_START_MAPPING_PREDICTION && tooltipVisible;
+
   return (
     <MapComponent
       controlsPosition={ControlsPosition.TOP_LEFT}
-      oamTileJSONURL={tileJSONURL}
       showTileBoundaries
       fitToBounds={!isSmallViewport}
       bounds={tmsBounds}
@@ -156,9 +164,10 @@ export const StartMappingMapComponent = ({
       zoomControls={!isSmallViewport}
       layerControl={!isSmallViewport}
       layerControlLayers={layers}
-      openAerialMap
       basemaps
       showCurrentZoom={!isSmallViewport}
+      openAerialMap={!modelInfoRequestIsPending}
+      oamTileJSONURL={tileJSONURL}
     >
       <AcceptedPredictionsLayer
         map={map}
@@ -169,6 +178,7 @@ export const StartMappingMapComponent = ({
         features={modelPredictions.rejected}
       />
       <AllPredictionsLayer map={map} features={modelPredictions.all} />
+
       {showPopup && (
         <PredictedFeatureActionPopup
           event={selectedEvent}

--- a/frontend/src/features/start-mapping/components/map/map.tsx
+++ b/frontend/src/features/start-mapping/components/map/map.tsx
@@ -169,15 +169,18 @@ export const StartMappingMapComponent = ({
       openAerialMap={!modelInfoRequestIsPending}
       oamTileJSONURL={tileJSONURL}
     >
-      <AcceptedPredictionsLayer
-        map={map}
-        features={modelPredictions.accepted}
-      />
-      <RejectedPredictionsLayer
-        map={map}
-        features={modelPredictions.rejected}
-      />
-      <AllPredictionsLayer map={map} features={modelPredictions.all} />
+      {!modelInfoRequestIsPending &&
+        <>
+          <AcceptedPredictionsLayer
+            map={map}
+            features={modelPredictions.accepted}
+          />
+          <RejectedPredictionsLayer
+            map={map}
+            features={modelPredictions.rejected}
+          />
+          <AllPredictionsLayer map={map} features={modelPredictions.all} />
+        </>}
 
       {showPopup && (
         <PredictedFeatureActionPopup

--- a/frontend/src/features/start-mapping/components/map/map.tsx
+++ b/frontend/src/features/start-mapping/components/map/map.tsx
@@ -169,7 +169,7 @@ export const StartMappingMapComponent = ({
       openAerialMap={!modelInfoRequestIsPending}
       oamTileJSONURL={tileJSONURL}
     >
-      {!modelInfoRequestIsPending &&
+      {!modelInfoRequestIsPending && (
         <>
           <AcceptedPredictionsLayer
             map={map}
@@ -180,7 +180,8 @@ export const StartMappingMapComponent = ({
             features={modelPredictions.rejected}
           />
           <AllPredictionsLayer map={map} features={modelPredictions.all} />
-        </>}
+        </>
+      )}
 
       {showPopup && (
         <PredictedFeatureActionPopup

--- a/frontend/src/features/start-mapping/components/mobile-drawer.tsx
+++ b/frontend/src/features/start-mapping/components/mobile-drawer.tsx
@@ -7,7 +7,7 @@ import { ModelDetailsButton } from "@/features/start-mapping/components/model-de
 import { ModelPredictionsTracker } from "@/features/start-mapping/components/model-predictions-tracker";
 import { ModelSettings } from "@/features/start-mapping/components/model-settings";
 import { TDownloadOptions, TQueryParams } from "@/app/routes/start-mapping";
-import { TModel, TModelPredictions, TTrainingDataset } from "@/types";
+import { TModelDetails, TModelPredictions } from "@/types";
 import { ToolTip } from "@/components/ui/tooltip";
 import { useState } from "react";
 import { START_MAPPING_PAGE_CONTENT } from "@/constants";
@@ -24,7 +24,6 @@ export const StartMappingMobileDrawer = ({
   updateQuery,
   modelDetailsPopupIsActive,
   clearPredictions,
-  trainingDataset,
   currentZoom,
   modelInfo,
 }: {
@@ -39,9 +38,8 @@ export const StartMappingMobileDrawer = ({
   query: TQueryParams;
   updateQuery: (newParams: TQueryParams) => void;
   clearPredictions: () => void;
-  trainingDataset: TTrainingDataset;
   currentZoom: number;
-  modelInfo: TModel;
+  modelInfo: TModelDetails;
 }) => {
   const [showDownloadOptions, setShowDownloadOptions] =
     useState<boolean>(false);
@@ -62,7 +60,6 @@ export const StartMappingMobileDrawer = ({
               map={map}
               disablePrediction={disablePrediction}
               modelPredictions={modelPredictions}
-              trainingDataset={trainingDataset}
               currentZoom={currentZoom}
               modelInfo={modelInfo}
             />

--- a/frontend/src/features/start-mapping/components/model-action.tsx
+++ b/frontend/src/features/start-mapping/components/model-action.tsx
@@ -3,11 +3,10 @@ import { Map } from "maplibre-gl";
 import { START_MAPPING_PAGE_CONTENT, TOAST_NOTIFICATIONS } from "@/constants";
 import {
   BBOX,
-  TModel,
+  TModelDetails,
   TModelPredictions,
   TModelPredictionsConfig,
   TQueryParams,
-  TTrainingDataset,
 } from "@/types";
 import { ToolTip } from "@/components/ui/tooltip";
 import { useCallback } from "react";
@@ -23,7 +22,6 @@ const ModelAction = ({
   map,
   disablePrediction,
   query,
-  trainingDataset,
   currentZoom,
   modelInfo,
 }: {
@@ -32,9 +30,8 @@ const ModelAction = ({
   map: Map | null;
   disablePrediction: boolean;
   query: TQueryParams;
-  trainingDataset: TTrainingDataset;
   currentZoom: number;
-  modelInfo: TModel;
+  modelInfo: TModelDetails;
 }) => {
   const { modelId } = useParams();
 
@@ -44,11 +41,11 @@ const ModelAction = ({
       area_threshold: query[SEARCH_PARAMS.area] as number,
       use_josm_q: query[SEARCH_PARAMS.useJOSMQ] as boolean,
       confidence: query[SEARCH_PARAMS.confidenceLevel] as number,
-      checkpoint: `/mnt/efsmount/data/trainings/dataset_${modelInfo?.dataset}/output/training_${modelInfo?.published_training}/checkpoint${PREDICTION_API_FILE_EXTENSIONS[modelInfo?.base_model as BASE_MODELS]}`,
+      checkpoint: `/mnt/efsmount/data/trainings/dataset_${modelInfo?.dataset?.id}/output/training_${modelInfo?.published_training}/checkpoint${PREDICTION_API_FILE_EXTENSIONS[modelInfo?.base_model as BASE_MODELS]}`,
       max_angle_change: 15,
       model_id: modelId as string,
       skew_tolerance: 15,
-      source: trainingDataset?.source_imagery as string,
+      source: modelInfo?.dataset?.source_imagery as string,
       zoom_level: currentZoom,
       bbox: [
         map?.getBounds().getWest(),
@@ -57,7 +54,7 @@ const ModelAction = ({
         map?.getBounds().getNorth(),
       ] as BBOX,
     };
-  }, [map, query, currentZoom, trainingDataset, modelInfo]);
+  }, [map, query, currentZoom, modelInfo]);
 
   const modelPredictionMutation = useGetModelPredictions({
     mutationConfig: {

--- a/frontend/src/features/start-mapping/components/model-details-popup.tsx
+++ b/frontend/src/features/start-mapping/components/model-details-popup.tsx
@@ -4,8 +4,7 @@ import { extractDatePart, roundNumber, truncateString } from "@/utils";
 import { MobileDrawer } from "@/components/ui/drawer";
 import { Popup } from "@/components/ui/popup";
 import { SkeletonWrapper } from "@/components/ui/skeleton";
-import { TModelDetails, TTrainingDataset } from "@/types";
-import { useModelDetails } from "@/features/models/hooks/use-models";
+import { TModelDetails } from "@/types";
 import { useTrainingDetails } from "@/features/models/hooks/use-training";
 import { START_MAPPING_PAGE_CONTENT } from "@/constants";
 
@@ -13,84 +12,67 @@ const ModelDetailsPopUp = ({
   showPopup,
   anchor,
   handlePopup,
-  modelId,
-  model,
-  trainingDatasetIsError,
-  trainingDataset,
-  trainingDatasetIsPending,
+  modelInfo,
+  modelInfoRequestIsError,
+  modelInfoRequestIsPending,
   closeMobileDrawer,
 }: {
   showPopup: boolean;
   anchor: string;
   handlePopup: () => void;
-  modelId?: string;
-  model?: TModelDetails;
-  trainingDataset?: TTrainingDataset;
-  trainingDatasetIsPending?: boolean;
-  trainingDatasetIsError?: boolean;
+  modelInfo?: TModelDetails;
+  modelInfoRequestIsPending?: boolean;
+  modelInfoRequestIsError?: boolean;
   closeMobileDrawer: () => void;
 }) => {
-  const { data, isPending, isError } = useModelDetails(
-    modelId as string,
-    modelId ? modelId !== undefined : false,
-  );
-
   const {
     data: trainingDetails,
     isPending: trainingDetailsIsPending,
     isError: trainingDetailsError,
-  } = useTrainingDetails(
-    model?.published_training ?? (data?.published_training as number),
-  );
+  } = useTrainingDetails(modelInfo?.published_training as number);
   const { isSmallViewport } = useScreenSize();
 
   const popupContent = (
     <SkeletonWrapper
-      showSkeleton={Boolean(modelId && isPending)}
+      showSkeleton={modelInfoRequestIsPending}
       skeletonClassName="h-40"
     >
       <div className="flex flex-col gap-y-3 text-dark font-normal text-body-3">
         <p>
           {START_MAPPING_PAGE_CONTENT.modelDetails.popover.modelId}:{" "}
-          <span className="font-medium">{model?.id ?? data?.id}</span>
+          <span className="font-medium">{modelInfo?.id}</span>
         </p>
         <p>
           {START_MAPPING_PAGE_CONTENT.modelDetails.popover.description}:{" "}
-          <span className="font-medium">
-            {model?.description ?? data?.description}
-          </span>
+          <span className="font-medium">{modelInfo?.description}</span>
         </p>
         <p>
           {START_MAPPING_PAGE_CONTENT.modelDetails.popover.lastModified}:{" "}
           <span className="font-medium">
-            {extractDatePart(
-              model?.last_modified ?? (data?.last_modified as string),
-            )}
+            {extractDatePart(modelInfo?.last_modified as string)}
           </span>
         </p>
         <p>
           {START_MAPPING_PAGE_CONTENT.modelDetails.popover.trainingId}:{" "}
-          <span className="font-medium">
-            {model?.published_training ?? data?.published_training}
-          </span>
+          <span className="font-medium">{modelInfo?.published_training}</span>
         </p>
         <p>
           {START_MAPPING_PAGE_CONTENT.modelDetails.popover.datasetId}:{" "}
-          <span className="font-medium">{model?.dataset ?? data?.dataset}</span>
+          <span className="font-medium">{modelInfo?.dataset.id}</span>
         </p>
         <p className="flex items-center gap-x-1 text-nowrap flex-wrap">
           {START_MAPPING_PAGE_CONTENT.modelDetails.popover.datasetName}:{" "}
           <SkeletonWrapper
-            showSkeleton={trainingDatasetIsPending}
+            showSkeleton={modelInfoRequestIsPending}
             skeletonClassName="w-20 h-4"
           >
             <span
               className="text-dark font-medium text-wrap"
-              title={trainingDataset?.name}
+              title={modelInfo?.dataset?.name}
             >
-              {trainingDatasetIsError
+              {modelInfoRequestIsError
                 ? "N/A"
-                : truncateString(trainingDataset?.name, 40)}{" "}
+                : truncateString(modelInfo?.dataset?.name, 40)}{" "}
             </span>
           </SkeletonWrapper>
         </p>
@@ -112,14 +94,12 @@ const ModelDetailsPopUp = ({
         <p>
           {START_MAPPING_PAGE_CONTENT.modelDetails.popover.accuracy}:{" "}
           <span className="font-medium">
-            {roundNumber(model?.accuracy ?? (data?.accuracy as number), 2)}%
+            {roundNumber(modelInfo?.accuracy as number, 2)}%
           </span>
         </p>
         <p>
           {START_MAPPING_PAGE_CONTENT.modelDetails.popover.baseModel}:{" "}
-          <span className="font-medium">
-            {model?.base_model ?? data?.base_model}
-          </span>
+          <span className="font-medium">{modelInfo?.base_model}</span>
         </p>
       </div>
     </SkeletonWrapper>
@@ -135,7 +115,7 @@ const ModelDetailsPopUp = ({
         canClose
       >
         <div className={`app-padding flex flex-col`}>
-          {!model && isError ? (
+          {!modelInfo && modelInfoRequestIsError ? (
             <div>{START_MAPPING_PAGE_CONTENT.modelDetails.error}</div>
           ) : (
             <div className="flex flex-col gap-y-4 text-dark">
@@ -160,7 +140,7 @@ const ModelDetailsPopUp = ({
       <div
         className={`border bg-white border-gray-border shadown-sm rounded-xl w-[350px] scrollable p-5 max-h-[400px] overflow-y-auto flex flex-col`}
       >
-        {!model && isError ? (
+        {!modelInfo && modelInfoRequestIsError ? (
           <div>{START_MAPPING_PAGE_CONTENT.modelDetails.error}</div>
         ) : (
           <div className="flex flex-col gap-y-4 text-dark">

--- a/frontend/src/hooks/use-map-instance.ts
+++ b/frontend/src/hooks/use-map-instance.ts
@@ -45,6 +45,7 @@ export const useMapInstance = (pmtiles: boolean = false) => {
     if (!map) return;
     // There is a mismatch of 1 in the mag.getZoom() results and the actual zoom level of the map.
     // Adding 1 to the result resolves it.
+
     setCurrentZoom(Math.round(map.getZoom()) + 1);
   }, [map]);
 

--- a/frontend/src/layouts/root-layout.tsx
+++ b/frontend/src/layouts/root-layout.tsx
@@ -25,12 +25,13 @@ export const RootLayout = () => {
       <AuthenticationModal
         isOpen={state?.backgroundLocation && !isAuthenticated}
       />
-      <main className="min-h-screen relative  mx-auto flex flex-col justify-between">
-        {!pathname.includes(APPLICATION_ROUTES.AUTH_CALLBACK) && <Banner />}
-
+      <main className="min-h-screen relative mx-auto flex flex-col justify-between">
         {!pathname.includes(APPLICATION_ROUTES.AUTH_CALLBACK) &&
           !pathname.includes(APPLICATION_ROUTES.START_MAPPING_BASE) && (
-            <NavBar />
+            <>
+              <Banner />
+              <NavBar />
+            </>
           )}
 
         <div
@@ -39,6 +40,7 @@ export const RootLayout = () => {
         >
           <Outlet />
         </div>
+
         {!pathname.includes(APPLICATION_ROUTES.START_MAPPING_BASE) &&
           !pathname.includes(APPLICATION_ROUTES.AUTH_CALLBACK) && <Footer />}
       </main>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -70,6 +70,7 @@ export type PaginatedTrainings = {
 
 export type TModelDetails = TModel & {
   description: string;
+  dataset: TTrainingDataset;
 };
 
 export type TTrainingAreaFeature = {


### PR DESCRIPTION
This PR will be closing #339 and #336.

### Description

The predicted features are now persisted in LocalStorage. The users can resume mapping and clear the storage using the 'clear' button.

In addition, it includes an update to the model details response object across the app, which was updated from the backend.
