### PR TITLE
feat: improved history stack handling

### DIFF
--- a/frontend/src/app/routes/models/model-details-card.tsx
+++ b/frontend/src/app/routes/models/model-details-card.tsx
@@ -1,5 +1,5 @@
 import ModelEnhancementDialog from "@/features/models/components/dialogs/model-enhancement-dialog";
-import { APPLICATION_ROUTES, MODELS_CONTENT } from "@/constants";
+import { MODELS_CONTENT } from "@/constants";
 import { BackButton, ButtonWithIcon } from "@/components/ui/button";
 import { Head } from "@/components/seo";
 import { Image } from "@/components/ui/image";

--- a/frontend/src/app/routes/models/model-details-card.tsx
+++ b/frontend/src/app/routes/models/model-details-card.tsx
@@ -19,6 +19,8 @@ import {
 } from "@/features/models/components";
 import { useModelsContext } from "@/app/providers/models-provider";
 
+
+
 export const ModelDetailsPage = () => {
   const {
     isOpened: isModelFilesDialogOpened,
@@ -62,7 +64,7 @@ export const ModelDetailsPage = () => {
         trainingId={data?.published_training}
         datasetId={data?.dataset?.id}
       />
-      <BackButton className="mt-6" route={APPLICATION_ROUTES.MODELS} />
+      <BackButton className="mt-6" />
       <div className="my-12 flex flex-col gap-y-20">
         <ModelDetailsInfo
           data={data as TModelDetails}

--- a/frontend/src/app/routes/start-mapping.tsx
+++ b/frontend/src/app/routes/start-mapping.tsx
@@ -173,42 +173,42 @@ export const StartMappingPage = () => {
     () => [
       ...(modelPredictions.accepted.length > 0
         ? [
-            {
-              value:
-                START_MAPPING_PAGE_CONTENT.map.controls.legendControl
-                  .acceptedPredictions,
-              subLayers: [
-                ACCEPTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
-                ACCEPTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
-              ],
-            },
-          ]
+          {
+            value:
+              START_MAPPING_PAGE_CONTENT.map.controls.legendControl
+                .acceptedPredictions,
+            subLayers: [
+              ACCEPTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
+              ACCEPTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+            ],
+          },
+        ]
         : []),
       ...(modelPredictions.rejected.length > 0
         ? [
-            {
-              value:
-                START_MAPPING_PAGE_CONTENT.map.controls.legendControl
-                  .rejectedPredictions,
-              subLayers: [
-                REJECTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
-                REJECTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
-              ],
-            },
-          ]
+          {
+            value:
+              START_MAPPING_PAGE_CONTENT.map.controls.legendControl
+                .rejectedPredictions,
+            subLayers: [
+              REJECTED_MODEL_PREDICTIONS_FILL_LAYER_ID,
+              REJECTED_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+            ],
+          },
+        ]
         : []),
       ...(modelPredictions.all.length > 0
         ? [
-            {
-              value:
-                START_MAPPING_PAGE_CONTENT.map.controls.legendControl
-                  .predictionResults,
-              subLayers: [
-                ALL_MODEL_PREDICTIONS_FILL_LAYER_ID,
-                ALL_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
-              ],
-            },
-          ]
+          {
+            value:
+              START_MAPPING_PAGE_CONTENT.map.controls.legendControl
+                .predictionResults,
+            subLayers: [
+              ALL_MODEL_PREDICTIONS_FILL_LAYER_ID,
+              ALL_MODEL_PREDICTIONS_OUTLINE_LAYER_ID,
+            ],
+          },
+        ]
         : []),
     ],
     [modelPredictions],
@@ -370,7 +370,7 @@ export const StartMappingPage = () => {
                 onClose={onDropdownHide}
                 onShow={onDropdownShow}
                 isOpened={dropdownIsOpened}
-                modelId={modelInfo?.id}
+
               />
             </div>
             <div className="absolute top-[10vh] right-4 z-[2] flex flex-col gap-y-4 items-end">

--- a/frontend/src/components/ui/button/back-button.tsx
+++ b/frontend/src/components/ui/button/back-button.tsx
@@ -1,24 +1,18 @@
 import { ArrowBackIcon } from "@/components/ui/icons";
-import { useNavigate } from "react-router-dom";
+import { useHistory } from "@/hooks/use-history";
+
 
 const BackButton = ({
   className,
-  route,
 }: {
   className?: string;
-  route?: string;
 }) => {
-  const navigate = useNavigate();
+
+  const { goBack } = useHistory()
   return (
     <button
       className={`flex items-center gap-x-2 ${className}`}
-      onClick={() => {
-        if (route) {
-          navigate(route);
-        } else {
-          navigate(-1);
-        }
-      }}
+      onClick={goBack}
       title="Go back"
     >
       <ArrowBackIcon className="icon md:icon-lg" />

--- a/frontend/src/features/start-mapping/components/header.tsx
+++ b/frontend/src/features/start-mapping/components/header.tsx
@@ -72,7 +72,6 @@ const StartMappingHeader = ({
             onClose={onFAIRLogoDropdownHide}
             onShow={onFAIRLogoDropdownShow}
             isOpened={FAIRLogoDropdownIsOpened}
-            modelId={modelInfo?.id}
           />
           <div className="flex flex-col md:flex-row md:items-center gap-x-4 z-10">
             <p
@@ -108,8 +107,8 @@ const StartMappingHeader = ({
                   content={
                     !modelPredictionsExist
                       ? START_MAPPING_PAGE_CONTENT.actions.disabledModeTooltip(
-                          "see actions",
-                        )
+                        "see actions",
+                      )
                       : null
                   }
                 >

--- a/frontend/src/features/start-mapping/components/logo-with-dropdown.tsx
+++ b/frontend/src/features/start-mapping/components/logo-with-dropdown.tsx
@@ -11,14 +11,13 @@ type BrandLogoWithDropDownProps = {
   isOpened: boolean;
   onClose: () => void;
   onShow: () => void;
-  modelId?: string;
+
 };
 
 export const BrandLogoWithDropDown = ({
   isOpened,
   onClose,
   onShow,
-  modelId,
 }: BrandLogoWithDropDownProps) => {
 
   const { goBack } = useHistory()

--- a/frontend/src/features/start-mapping/components/logo-with-dropdown.tsx
+++ b/frontend/src/features/start-mapping/components/logo-with-dropdown.tsx
@@ -5,8 +5,7 @@ import { ELEMENT_DISTANCE_FROM_NAVBAR } from "@/config";
 import { Link } from "@/components/ui/link";
 import { navLinks } from "@/constants/general";
 import { NavLogo } from "@/components/layout";
-import { useNavigate } from "react-router-dom";
-import { APPLICATION_ROUTES } from "@/constants";
+import { useHistory } from "@/hooks/use-history";
 
 type BrandLogoWithDropDownProps = {
   isOpened: boolean;
@@ -21,7 +20,8 @@ export const BrandLogoWithDropDown = ({
   onShow,
   modelId,
 }: BrandLogoWithDropDownProps) => {
-  const navigate = useNavigate();
+
+  const { goBack } = useHistory()
   const navItems = navLinks.map((link, id) => (
     <li key={`${link.title}-${id}`}>
       <Link
@@ -50,13 +50,7 @@ export const BrandLogoWithDropDown = ({
         <Divider />
         <button
           className="text-body-3  block w-full px-4 py-2 text-start hover:bg-off-white hover:rounded-b-xl text-primary"
-          onClick={() => {
-            /**
-             * Since this is on the start-mapping page, when they click on stop mapping, regardless of how they got here,
-             * they will be redirected to the model card/details page.
-             */
-            navigate(`${APPLICATION_ROUTES.MODELS}/${modelId}`);
-          }}
+          onClick={goBack}
         >
           Stop Mapping
         </button>

--- a/frontend/src/hooks/__tests__/use-history.test.ts
+++ b/frontend/src/hooks/__tests__/use-history.test.ts
@@ -1,0 +1,44 @@
+import { renderHook } from '@testing-library/react';
+import { useHistory } from '../use-history';
+import { useNavigate } from 'react-router-dom';
+import { vi, describe, it, expect } from 'vitest';
+
+vi.mock('react-router-dom', () => ({
+    useNavigate: vi.fn(),
+}));
+
+describe('useHistory', () => {
+    it('should navigate back if history length is greater than 2', () => {
+        const navigate = vi.fn();
+        (useNavigate as vi.Mock).mockReturnValue(navigate);
+
+        Object.defineProperty(window, 'history', {
+            value: {
+                length: 3,
+            },
+            writable: true,
+        });
+
+        const { result } = renderHook(() => useHistory());
+
+        result.current.goBack();
+        expect(navigate).toHaveBeenCalledWith(-1);
+    });
+
+    it('should navigate to root if history length is not greater than 2', () => {
+        const navigate = vi.fn();
+        (useNavigate as vi.Mock).mockReturnValue(navigate);
+
+        Object.defineProperty(window, 'history', {
+            value: {
+                length: 2,
+            },
+            writable: true,
+        });
+
+        const { result } = renderHook(() => useHistory());
+
+        result.current.goBack();
+        expect(navigate).toHaveBeenCalledWith('/', { replace: true });
+    });
+});

--- a/frontend/src/hooks/__tests__/use-history.test.ts
+++ b/frontend/src/hooks/__tests__/use-history.test.ts
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 import { renderHook } from '@testing-library/react';
 import { useHistory } from '../use-history';
 import { useNavigate } from 'react-router-dom';

--- a/frontend/src/hooks/use-history.ts
+++ b/frontend/src/hooks/use-history.ts
@@ -1,0 +1,31 @@
+
+/**
+ * Custom hook that provides a `goBack` function to navigate back in the browser history.
+ * If there is no history to go back to, it navigates to the root path ('/').
+ *
+ * @returns {Object} An object containing the `goBack` function.
+ *
+ * @example
+ * const { goBack } = useHistory();
+ * goBack(); // Navigates back in history or to the root path if no history exists.
+ */
+import { useNavigate } from "react-router-dom";
+
+
+export const useHistory = () => {
+
+    const navigate = useNavigate();
+    console.log(window.history)
+    const goBack = () => {
+        /**
+         * Why 2?
+         * Ref: https://stackoverflow.com/questions/9564041/why-history-length-is-2-for-the-first-page/9564075
+         */
+        if ((window.history?.length && window.history.length > 2)) {
+            navigate(-1);
+        } else {
+            navigate('/', { replace: true });
+        }
+    }
+    return { goBack }
+}

--- a/frontend/src/hooks/use-history.ts
+++ b/frontend/src/hooks/use-history.ts
@@ -15,7 +15,7 @@ import { useNavigate } from "react-router-dom";
 export const useHistory = () => {
 
     const navigate = useNavigate();
-    console.log(window.history)
+
     const goBack = () => {
         /**
          * Why 2?

--- a/frontend/src/layouts/model-forms-layout.tsx
+++ b/frontend/src/layouts/model-forms-layout.tsx
@@ -26,43 +26,43 @@ const pages: {
   icon: React.ElementType;
   path: string;
 }[] = [
-  {
-    id: 1,
-    title: MODELS_CONTENT.modelCreation.progressStepper.modelDetails,
-    icon: TagsIcon,
-    path: MODELS_ROUTES.DETAILS,
-  },
-  {
-    id: 2,
-    title: MODELS_CONTENT.modelCreation.progressStepper.trainingDataset,
-    icon: DatabaseIcon,
-    path: MODELS_ROUTES.TRAINING_DATASET,
-  },
-  {
-    id: 3,
-    title: MODELS_CONTENT.modelCreation.progressStepper.trainingArea,
-    icon: SquareShadowIcon,
-    path: MODELS_ROUTES.TRAINING_AREA,
-  },
-  {
-    id: 4,
-    title: MODELS_CONTENT.modelCreation.progressStepper.trainingSettings,
-    icon: SettingsIcon,
-    path: MODELS_ROUTES.TRAINING_SETTINGS,
-  },
-  {
-    id: 5,
-    title: MODELS_CONTENT.modelCreation.progressStepper.submitModel,
-    icon: CloudIcon,
-    path: MODELS_ROUTES.MODEL_SUMMARY,
-  },
-  {
-    id: 6,
-    title: MODELS_CONTENT.modelCreation.progressStepper.confirmation,
-    icon: StarIcon,
-    path: MODELS_ROUTES.CONFIRMATION,
-  },
-];
+    {
+      id: 1,
+      title: MODELS_CONTENT.modelCreation.progressStepper.modelDetails,
+      icon: TagsIcon,
+      path: MODELS_ROUTES.DETAILS,
+    },
+    {
+      id: 2,
+      title: MODELS_CONTENT.modelCreation.progressStepper.trainingDataset,
+      icon: DatabaseIcon,
+      path: MODELS_ROUTES.TRAINING_DATASET,
+    },
+    {
+      id: 3,
+      title: MODELS_CONTENT.modelCreation.progressStepper.trainingArea,
+      icon: SquareShadowIcon,
+      path: MODELS_ROUTES.TRAINING_AREA,
+    },
+    {
+      id: 4,
+      title: MODELS_CONTENT.modelCreation.progressStepper.trainingSettings,
+      icon: SettingsIcon,
+      path: MODELS_ROUTES.TRAINING_SETTINGS,
+    },
+    {
+      id: 5,
+      title: MODELS_CONTENT.modelCreation.progressStepper.submitModel,
+      icon: CloudIcon,
+      path: MODELS_ROUTES.MODEL_SUMMARY,
+    },
+    {
+      id: 6,
+      title: MODELS_CONTENT.modelCreation.progressStepper.confirmation,
+      icon: StarIcon,
+      path: MODELS_ROUTES.CONFIRMATION,
+    },
+  ];
 
 export const ModelFormsLayout = () => {
   const { pathname } = useLocation();


### PR DESCRIPTION
This PR will be closing #358. It improved the history stack handling by creating a reusable hook that handles situations without history, and otherwise.

### Checklists

- [X] Tests

### How to Test

#### Scenario 1 - A user was given a direct link to the `start mapping` page.

1. Visit https://f-a-ir-emmanuels-projects-1886bda9.vercel.app/start-mapping/368 .
2. Authenticate if you haven't already.
3. Click the dropdown from the fAIr logo and click on 'Stop Mapping'.
4. Because there is not history, it should return you to the landing page.

#### Scenario 2 - A user directly navigates to the model card from any other page in the application.

1. Visit https://f-a-ir-emmanuels-projects-1886bda9.vercel.app/account/models .
2. Authenticate if necessary.
3. Click on a model to open the model card.
4. Click on 'Go Back', it should take you to the previous page.

