### PR TITLE
chore: update Terra Draw to version 1.3.0 and use the MapLibre adapter

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,8 @@
     "react-router-dom": "^6.26.2",
     "remark-gfm": "^4.0.0",
     "tailwind-merge": "^2.5.2",
-    "terra-draw": "1.0.0-beta.8",
+    "terra-draw": "^1.3.0",
+    "terra-draw-maplibre-gl-adapter": "^1.0.1",
     "vaul": "^1.1.2",
     "xmlbuilder2": "^3.1.1"
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -88,8 +88,11 @@ importers:
         specifier: ^2.5.2
         version: 2.5.2
       terra-draw:
-        specifier: 1.0.0-beta.8
-        version: 1.0.0-beta.8
+        specifier: ^1.3.0
+        version: 1.3.0
+      terra-draw-maplibre-gl-adapter:
+        specifier: ^1.0.1
+        version: 1.0.1(maplibre-gl@4.7.1)(terra-draw@1.3.0)
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3141,8 +3144,14 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
-  terra-draw@1.0.0-beta.8:
-    resolution: {integrity: sha512-40kOjgOQkDDmRIkz7QZ4urjwb9v/+Zm7tPf3RqeDY4UtKm3JodZ5iz3fFm93u3nzd+QVQlOZF0VF15ew0esQ7A==}
+  terra-draw-maplibre-gl-adapter@1.0.1:
+    resolution: {integrity: sha512-B5zM6OhOEwcYegNLP2HybOc+V0ZaQNYuSkOiAcGABV6ZVd5zZCX51GIXcAgOL07okcs1D+7a+4zCgqtD/fLgTg==}
+    peerDependencies:
+      maplibre-gl: '>=4'
+      terra-draw: ^1.0.0
+
+  terra-draw@1.3.0:
+    resolution: {integrity: sha512-k1WdoTp3aWmeczb6qjPP51FGzPbaA7deyOoVnGl6nqq3eDG1Jdn7RS5S0/jPSUb5nN8ek+tK8tobkj01yTwv8Q==}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -7030,7 +7039,12 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  terra-draw@1.0.0-beta.8: {}
+  terra-draw-maplibre-gl-adapter@1.0.1(maplibre-gl@4.7.1)(terra-draw@1.3.0):
+    dependencies:
+      maplibre-gl: 4.7.1
+      terra-draw: 1.3.0
+
+  terra-draw@1.3.0: {}
 
   text-table@0.2.0: {}
 

--- a/frontend/src/components/map/setups/setup-terra-draw.ts
+++ b/frontend/src/components/map/setups/setup-terra-draw.ts
@@ -1,11 +1,11 @@
 import maplibregl from "maplibre-gl";
-import { HexColorStyling } from "node_modules/terra-draw/dist/common";
 import {
   TerraDraw,
-  TerraDrawMapLibreGLAdapter,
   ValidateNotSelfIntersecting,
   TerraDrawRectangleMode,
+  TerraDrawExtend
 } from "terra-draw";
+import { TerraDrawMapLibreGLAdapter } from "terra-draw-maplibre-gl-adapter";
 import {
   TRAINING_AREAS_AOI_FILL_COLOR,
   TRAINING_AREAS_AOI_FILL_OPACITY,
@@ -50,17 +50,19 @@ export const setupTerraDraw = (map: maplibregl.Map) => {
           if (updateType === "finish" || updateType === "commit") {
             return ValidateNotSelfIntersecting(feature);
           }
-          return true;
+          return {
+            valid: true
+          };
         },
         styles: {
           // Fill colour (a string containing a 6 digit Hex color)
-          fillColor: TRAINING_AREAS_AOI_FILL_COLOR as HexColorStyling,
+          fillColor: TRAINING_AREAS_AOI_FILL_COLOR as TerraDrawExtend.HexColorStyling,
 
           // Fill opacity (0 - 1)
           fillOpacity: TRAINING_AREAS_AOI_FILL_OPACITY,
 
           // Outline colour (Hex color)
-          outlineColor: TRAINING_AREAS_AOI_OUTLINE_COLOR as HexColorStyling,
+          outlineColor: TRAINING_AREAS_AOI_OUTLINE_COLOR as TerraDrawExtend.HexColorStyling,
 
           //Outline width (Integer)
           outlineWidth: TRAINING_AREAS_AOI_OUTLINE_WIDTH,


### PR DESCRIPTION
This PR updates Terra Draw to a v1.3.0 and away from the beta release. It also uses `terra-draw-maplibre-gl-adapter` as Adapters are now split out from the core library.

I would recommend someone manually tests this as I haven't been able to get to the map drawing aspect of the application yet.