### PR TITLE
Fix/Zoom Level Persistence

### DIFF
--- a/frontend/src/features/start-mapping/components/model-action.tsx
+++ b/frontend/src/features/start-mapping/components/model-action.tsx
@@ -9,7 +9,7 @@ import {
   TQueryParams,
 } from "@/types";
 import { ToolTip } from "@/components/ui/tooltip";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { useGetModelPredictions } from "@/features/start-mapping/hooks/use-model-predictions";
 import { SEARCH_PARAMS } from "@/app/routes/start-mapping";
 import { PREDICTION_API_FILE_EXTENSIONS } from "@/config";
@@ -34,6 +34,9 @@ const ModelAction = ({
   modelInfo: TModelDetails;
 }) => {
   const { modelId } = useParams();
+  const [predictionZoomLevel, setPredictionZoomLevel] = useState<number | null>(
+    null,
+  );
 
   const getTrainingConfig = useCallback((): TModelPredictionsConfig => {
     return {
@@ -46,7 +49,7 @@ const ModelAction = ({
       model_id: modelId as string,
       skew_tolerance: 15,
       source: modelInfo?.dataset?.source_imagery as string,
-      zoom_level: currentZoom,
+      zoom_level: predictionZoomLevel ?? currentZoom,
       bbox: [
         map?.getBounds().getWest(),
         map?.getBounds().getSouth(),
@@ -54,7 +57,7 @@ const ModelAction = ({
         map?.getBounds().getNorth(),
       ] as BBOX,
     };
-  }, [map, query, currentZoom, modelInfo]);
+  }, [map, query, currentZoom, modelInfo, predictionZoomLevel]);
 
   const modelPredictionMutation = useGetModelPredictions({
     mutationConfig: {
@@ -65,7 +68,10 @@ const ModelAction = ({
         const conflatedResults = handleConflation(
           modelPredictions,
           data.features,
-          getTrainingConfig(),
+          {
+            ...getTrainingConfig(),
+            zoom_level: predictionZoomLevel ?? currentZoom,
+          },
         );
         setModelPredictions(conflatedResults);
       },
@@ -75,8 +81,9 @@ const ModelAction = ({
 
   const handlePrediction = useCallback(async () => {
     if (!map) return;
+    setPredictionZoomLevel(currentZoom);
     await modelPredictionMutation.mutateAsync(getTrainingConfig());
-  }, [getTrainingConfig, modelPredictionMutation, map]);
+  }, [getTrainingConfig, modelPredictionMutation, map, currentZoom]);
 
   return (
     <div className="flex gap-y-3 flex-col-reverse flex-wrap  md:items-center md:flex-row md:justify-between md:gap-x-2 md:flex-nowrap">


### PR DESCRIPTION
### What does this PR do

Currently, when you run a prediction at a zoom level and you zoom out, the current zoom will be appended to the property of the predicted feature (which was predicted at a different zoom level, e.,g 20). So this leads to a validation error when accepting/rejecting the feature.

This PR fixes that.

### How to Test

1. Visit: https://f-a-ir-emmanuels-projects-1886bda9.vercel.app/start-mapping/356
2. Authenticate if you haven't already.
3. Run prediction at zoom 19/20/21.
4. Zoom out/in while the prediction is running.
5. Click on the prediction feature and try to accept/reject. 
6. It should work without any issues.


