### PR TITLE
Make a start at optimising the backend container image builds

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,38 +1,39 @@
-FROM tensorflow/tensorflow:2.9.2-gpu
-
+FROM tensorflow/tensorflow:2.9.2-gpu AS base
 RUN apt-get update && \
     apt-get install -y python3-opencv gdal-bin libgdal-dev && \
     add-apt-repository ppa:ubuntugis/ppa && \
     apt-get update && \
     rm -rf /var/lib/apt/lists/*
-
 ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
 ENV C_INCLUDE_PATH=/usr/include/gdal
 
 
+
+FROM base AS build
 RUN pip install numpy==1.23.5
 RUN pip install --global-option=build_ext --global-option="-I/usr/include/gdal" GDAL==$(gdal-config --version)
-
-
 COPY docker/ramp/docker-requirements.txt /tmp/docker-requirements.txt
 RUN pip install -r /tmp/docker-requirements.txt
-
-
 COPY requirements.txt requirements.txt
 COPY api-requirements.txt api-requirements.txt
 # Don't use legacy resolver , TODO : fix this dependencies 
 # RUN pip install --use-deprecated=legacy-resolver -r api-requirements.txt 
-
-RUN pip install setuptools==68.2.2
-RUN pip install wheel==0.41.3
-RUN pip install build==1.0.0
-
-RUN  pip install  -r requirements.txt 
-
-# RUN pip install --use-deprecated=legacy-resolver -r requirements.txt 
+RUN pip install setuptools==68.2.2 wheel==0.41.3 build==1.0.0
+RUN pip install -r requirements.txt
 COPY docker/ramp/solaris /tmp/solaris
 RUN pip install /tmp/solaris --use-feature=in-tree-build && \
     pip install scikit-fmm --use-feature=in-tree-build
 
-WORKDIR /app
+
+
+FROM base AS run
+COPY --from=build /usr/local/lib/python3.*/dist-packages /usr/local/lib/python3.*/dist-packages
 COPY . /app
+
+
+
+FROM scratch
+ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
+ENV C_INCLUDE_PATH=/usr/include/gdal
+COPY --from=run / /
+WORKDIR /app

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,10 +17,6 @@ FROM base AS gdal-deps
 RUN pip install numpy==1.23.5
 RUN pip install --global-option=build_ext --global-option="-I/usr/include/gdal" GDAL==$(gdal-config --version)
 
-FROM base AS docker-deps
-COPY docker/ramp/docker-requirements.txt /tmp/docker-requirements.txt
-RUN pip install -r /tmp/docker-requirements.txt
-
 FROM base AS worker-deps
 COPY requirements.txt requirements.txt
 # FIXME api-requirements should be removed from this stage
@@ -33,18 +29,20 @@ COPY api-requirements.txt api-requirements.txt
 # RUN pip install --use-deprecated=legacy-resolver -r api-requirements.txt 
 RUN pip install -r api-requirements.txt
 
-FROM base AS solaris-deps
+FROM base AS docker-plus-solaris-deps
+COPY docker/ramp/docker-requirements.txt /tmp/docker-requirements.txt
 COPY docker/ramp/solaris /tmp/solaris
-RUN pip install /tmp/solaris && \
-    pip install scikit-fmm
+RUN pip install /tmp/solaris
+# docker-requirements are required to install packaging==21.3 for scikit-fmm to succeed
+RUN pip install -r /tmp/docker-requirements.txt
+RUN pip install scikit-fmm==2024.5.29
 
 
 FROM base AS run
 COPY --from=gdal-deps /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
-COPY --from=docker-deps /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
 COPY --from=worker-deps /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
 COPY --from=api-deps /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
-COPY --from=solaris-deps /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
+COPY --from=docker-plus-solaris-deps /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
 COPY . /app
 
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,17 +23,22 @@ RUN pip install -r /tmp/docker-requirements.txt
 
 FROM base AS worker-deps
 COPY requirements.txt requirements.txt
+# FIXME api-requirements should be removed from this stage
+# (removed from requirements.txt) 
+COPY api-requirements.txt api-requirements.txt
 RUN pip install -r requirements.txt
 
 FROM base AS api-deps
 COPY api-requirements.txt api-requirements.txt
+# RUN pip install --use-deprecated=legacy-resolver -r api-requirements.txt 
 RUN pip install -r api-requirements.txt
 
 FROM base AS solaris-deps
 COPY docker/ramp/solaris /tmp/solaris
-RUN pip install /tmp/solaris --use-feature=in-tree-build && \
+# pip upgrade required to use in-tree-build
+RUN pip install --upgrade pip && \
+    pip install /tmp/solaris --use-feature=in-tree-build && \
     pip install scikit-fmm --use-feature=in-tree-build
-
 
 
 FROM base AS run

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,7 +27,7 @@ RUN pip install /tmp/solaris --use-feature=in-tree-build && \
 
 
 FROM base AS run
-COPY --from=build /usr/local/lib/python3.*/dist-packages /usr/local/lib/python3.*/dist-packages
+COPY --from=build /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
 COPY . /app
 
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -35,10 +35,8 @@ RUN pip install -r api-requirements.txt
 
 FROM base AS solaris-deps
 COPY docker/ramp/solaris /tmp/solaris
-# pip upgrade required to use in-tree-build
-RUN pip install --upgrade pip && \
-    pip install /tmp/solaris --use-feature=in-tree-build && \
-    pip install scikit-fmm --use-feature=in-tree-build
+RUN pip install /tmp/solaris && \
+    pip install scikit-fmm
 
 
 FROM base AS run

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,6 +17,10 @@ FROM base AS gdal-deps
 RUN pip install numpy==1.23.5
 RUN pip install --global-option=build_ext --global-option="-I/usr/include/gdal" GDAL==$(gdal-config --version)
 
+FROM base AS docker-deps
+COPY docker/ramp/docker-requirements.txt /tmp/docker-requirements.txt
+RUN pip install -r /tmp/docker-requirements.txt
+
 FROM base AS worker-deps
 COPY requirements.txt requirements.txt
 # FIXME api-requirements should be removed from this stage
@@ -29,20 +33,20 @@ COPY api-requirements.txt api-requirements.txt
 # RUN pip install --use-deprecated=legacy-resolver -r api-requirements.txt 
 RUN pip install -r api-requirements.txt
 
-FROM base AS docker-plus-solaris-deps
-COPY docker/ramp/docker-requirements.txt /tmp/docker-requirements.txt
+FROM base AS solaris-deps
 COPY docker/ramp/solaris /tmp/solaris
 RUN pip install /tmp/solaris
-# docker-requirements are required to install packaging==21.3 for scikit-fmm to succeed
-RUN pip install -r /tmp/docker-requirements.txt
-RUN pip install scikit-fmm==2024.5.29
+# pinning setuptools is required to avoid errors during scikit-fmm install
+RUN pip install --upgrade packaging>=23.1 setuptools==68.2.2 wheel==0.41.3 build==1.0.0 \
+    && pip install scikit-fmm==2024.5.29
 
 
 FROM base AS run
 COPY --from=gdal-deps /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
+COPY --from=docker-deps /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
 COPY --from=worker-deps /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
 COPY --from=api-deps /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
-COPY --from=docker-plus-solaris-deps /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
+COPY --from=solaris-deps /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
 COPY . /app
 
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,11 @@
 FROM tensorflow/tensorflow:2.9.2-gpu AS base
 RUN apt-get update && \
-    apt-get install -y python3-opencv gdal-bin libgdal-dev && \
-    add-apt-repository ppa:ubuntugis/ppa && \
+    apt-get install -y \
+      build-essential \
+      python3-opencv \
+      gdal-bin \
+      libgdal-dev \
+    && add-apt-repository ppa:ubuntugis/ppa && \
     apt-get update && \
     rm -rf /var/lib/apt/lists/*
 ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
@@ -9,17 +13,23 @@ ENV C_INCLUDE_PATH=/usr/include/gdal
 
 
 
-FROM base AS build
+FROM base AS gdal-deps
 RUN pip install numpy==1.23.5
 RUN pip install --global-option=build_ext --global-option="-I/usr/include/gdal" GDAL==$(gdal-config --version)
+
+FROM base AS docker-deps
 COPY docker/ramp/docker-requirements.txt /tmp/docker-requirements.txt
 RUN pip install -r /tmp/docker-requirements.txt
+
+FROM base AS worker-deps
 COPY requirements.txt requirements.txt
-COPY api-requirements.txt api-requirements.txt
-# Don't use legacy resolver , TODO : fix this dependencies 
-# RUN pip install --use-deprecated=legacy-resolver -r api-requirements.txt 
-RUN pip install setuptools==68.2.2 wheel==0.41.3 build==1.0.0
 RUN pip install -r requirements.txt
+
+FROM base AS api-deps
+COPY api-requirements.txt api-requirements.txt
+RUN pip install -r api-requirements.txt
+
+FROM base AS solaris-deps
 COPY docker/ramp/solaris /tmp/solaris
 RUN pip install /tmp/solaris --use-feature=in-tree-build && \
     pip install scikit-fmm --use-feature=in-tree-build
@@ -27,7 +37,11 @@ RUN pip install /tmp/solaris --use-feature=in-tree-build && \
 
 
 FROM base AS run
-COPY --from=build /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
+COPY --from=gdal-deps /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
+COPY --from=docker-deps /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
+COPY --from=worker-deps /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
+COPY --from=api-deps /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
+COPY --from=solaris-deps /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
 COPY . /app
 
 
@@ -35,5 +49,6 @@ COPY . /app
 FROM scratch
 ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
 ENV C_INCLUDE_PATH=/usr/include/gdal
+# Squash the final image
 COPY --from=run / /
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   postgres:
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - "6379:6379"
 
   backend-api:
-    image: ghcr.io/hotosm/fair_api:develop
+    image: ghcr.io/hotosm/fair_api:debug
     build:
       context: ./backend
       dockerfile: Dockerfile
@@ -36,7 +36,7 @@ services:
       - postgres
 
   backend-worker:
-    image: ghcr.io/hotosm/fair_api:develop
+    image: ghcr.io/hotosm/fair_api:debug
     build:
       context: ./backend
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - "6379:6379"
 
   backend-api:
-    image: ghcr.io/hotosm/fair/backend:debug
+    image: ghcr.io/hotosm/fair_api:develop
     build:
       context: ./backend
       dockerfile: Dockerfile
@@ -38,7 +38,7 @@ services:
       - postgres
 
   backend-worker:
-    image: ghcr.io/hotosm/fAIr/backend:debug
+    image: ghcr.io/hotosm/fair_api:develop
     build:
       context: ./backend
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,12 +21,12 @@ services:
       - "6379:6379"
 
   backend-api:
+    image: ghcr.io/hotosm/fair/backend:debug
     build:
       context: ./backend
       dockerfile: Dockerfile
     container_name: api
     command: python manage.py runserver 0.0.0.0:8000
-
     ports:
       - 8000:8000
     volumes:
@@ -38,6 +38,7 @@ services:
       - postgres
 
   backend-worker:
+    image: ghcr.io/hotosm/fAIr/backend:debug
     build:
       context: ./backend
       dockerfile: Dockerfile


### PR DESCRIPTION
## Issue

- We had a user report on slack that the image built took up all their disk space.
- Upon investigation, I noticed the final build in 19Gb and takes well over an hour to complete.

## This PR

- [x] Only have one build directive in the compose file. Currently we build the same image for the api and worker in parallel, meaning the build cache requirements are doubled from the start.
- [x] Optimise the backend dockerfile by making it multi-stage.
- [ ] ~~Push the final image to Github container registry, to avoid the lengthy build time for contributors (they can simply pull).~~ EDIT: I found `ghcr.io/hotosm/fair_api:develop`, so just referenced that instead.

The using a squashed multi-stage build shaved off 3GB, making it a total of 16GB now... I didn't get a chance to test it, but I see no reason why things would change (we simply remove the cache / temp files dumped during install). It could probably be optimised further, but I'll need to come back to it in another PR (or someone else could look at it 🙏)

Key question: do we **actually** need all the deps installed here?

### Not included

- I wanted to also address https://github.com/hotosm/fAIr/issues/171, but I noticed there are multiple dockerfiles in the repo, plus the requirements.txt imports the api-requirements.txt.
- I'm a bit time constrained currently so couldn't dig into what the implications of splitting out this dockerfile would be & if I need to update them all.
- I think before addressing this we should consolidate and reorganise our docker setup.
- The simplest solution would be to just add different stages `api-build` and `worker-build`, where we install only the required dependencies for each.
- Also, we could definitely shave a few GB by only including libgdalXX in the final build, and not libgdal-dev.