### PR TITLE
fix: patch for offline predictions results

### DIFF
--- a/frontend/src/app/routes/profile/offline-predictions.tsx
+++ b/frontend/src/app/routes/profile/offline-predictions.tsx
@@ -48,6 +48,7 @@ export const UserProfileOfflinePredictionsPage = () => {
         <PredictionResultDrawer
           tileServiceUrl={activePrediction.config.source}
           predictionId={activePrediction.id}
+          folder={activePrediction.config.folder}
           isOpened={isPredictionResultOpened}
           closeDialog={() => {
             // Cleanup to ensure fresh rendering

--- a/frontend/src/app/routes/profile/settings.tsx
+++ b/frontend/src/app/routes/profile/settings.tsx
@@ -8,6 +8,7 @@ import { Input, Switch } from "@/components/ui/form";
 import { CheckIcon, DeleteIcon } from "@/components/ui/icons";
 import { Image } from "@/components/ui/image";
 import { ToolTip } from "@/components/ui/tooltip";
+import { HOT_FAIR_LOCAL_STORAGE_ACCESS_TOKEN_KEY } from "@/config";
 import { USER_PROFILE_PAGE_CONTENT } from "@/constants/ui-contents/user-profile-content";
 import { ButtonVariant, INPUT_TYPES } from "@/enums";
 import { NotificationDeliveryMethod } from "@/enums/user-profile";
@@ -15,7 +16,9 @@ import {
   useEmailVerification,
   useUpdateUserProfile,
 } from "@/features/user-profile/hooks/use-user-profile";
+import useCopyToClipboard from "@/hooks/use-clipboard";
 import { useDialog } from "@/hooks/use-dialog";
+import { useLocalStorage } from "@/hooks/use-storage";
 import { showErrorToast, showSuccessToast, truncateString } from "@/utils";
 import { useState } from "react";
 
@@ -28,7 +31,8 @@ export const UserProfileSettingsPage = () => {
       message: "",
     },
   );
-
+  const { getValue } = useLocalStorage();
+  const { copyToClipboard } = useCopyToClipboard()
   const [showForm, setShowForm] = useState<boolean>(user?.email.length === 0);
 
   const [isEmailPending, setIsEmailPending] = useState<boolean>(false);
@@ -105,6 +109,10 @@ export const UserProfileSettingsPage = () => {
       },
     },
   });
+  const handleCopyAccessToken = async () => {
+    await copyToClipboard(getValue(HOT_FAIR_LOCAL_STORAGE_ACCESS_TOKEN_KEY) as string)
+    showSuccessToast('Access token copied to clipboard.')
+  }
 
   const { mutate: updateNotifications } = useUpdateUserProfile({
     mutationConfig: {
@@ -251,7 +259,7 @@ export const UserProfileSettingsPage = () => {
                 >
                   {isEmailPending
                     ? USER_PROFILE_PAGE_CONTENT.settings.form
-                        .submissionInProgress
+                      .submissionInProgress
                     : USER_PROFILE_PAGE_CONTENT.settings.form.submitButton}
                 </Button>
               </div>
@@ -311,16 +319,16 @@ export const UserProfileSettingsPage = () => {
                           isNotificationPending ||
                           (!user.email_verified &&
                             notification.key !==
-                              USER_PROFILE_PAGE_CONTENT.settings.notifications
-                                .notificationKeys.webTrainingNotification) ||
+                            USER_PROFILE_PAGE_CONTENT.settings.notifications
+                              .notificationKeys.webTrainingNotification) ||
                           (user.email.length === 0 &&
                             notification.key !==
-                              USER_PROFILE_PAGE_CONTENT.settings.notifications
-                                .notificationKeys.webTrainingNotification)
+                            USER_PROFILE_PAGE_CONTENT.settings.notifications
+                              .notificationKeys.webTrainingNotification)
                         }
                         checked={
                           notifications[
-                            notification.key as keyof typeof notifications
+                          notification.key as keyof typeof notifications
                           ]
                         }
                         handleSwitchChange={(e) => {
@@ -377,7 +385,7 @@ export const UserProfileSettingsPage = () => {
                   {!user.account_deletion_requested
                     ? USER_PROFILE_PAGE_CONTENT.settings.account.description
                     : USER_PROFILE_PAGE_CONTENT.settings.account
-                        .deleteRequestPending}
+                      .deleteRequestPending}
                 </p>
               </div>
               <ButtonWithIcon
@@ -392,6 +400,29 @@ export const UserProfileSettingsPage = () => {
                 onClick={openDialog}
                 size="small"
                 disabled={user.account_deletion_requested}
+              />
+            </div>
+          </div>
+          <div className="flex flex-col gap-y-6">
+            <div className="flex flex-col gap-y-6">
+              <div className="flex flex-col gap-y-1">
+                <p className="text-body-3 md:text-body-2">
+                  Access Token
+                </p>
+                <p className="text-grey text-body-3">
+                  ⚠️ Keep this token safe. Anyone with it can access your account.
+                </p>
+              </div>
+              <ButtonWithIcon
+                label={
+                  "Copy Access Token"
+                }
+                variant={ButtonVariant.PRIMARY}
+                uppercase={false}
+                className="!w-fit"
+                textClassName="p-0.5 md:px-1 md:py-2 text-body-4"
+                onClick={handleCopyAccessToken}
+                size="small"
               />
             </div>
           </div>

--- a/frontend/src/app/routes/profile/settings.tsx
+++ b/frontend/src/app/routes/profile/settings.tsx
@@ -5,7 +5,7 @@ import { DeleteModal } from "@/components/shared/modals";
 import { Button, ButtonWithIcon } from "@/components/ui/button";
 import { Dialog } from "@/components/ui/dialog";
 import { Input, Switch } from "@/components/ui/form";
-import { CheckIcon, DeleteIcon } from "@/components/ui/icons";
+import { CheckIcon, ClipboardIcon, DeleteIcon } from "@/components/ui/icons";
 import { Image } from "@/components/ui/image";
 import { ToolTip } from "@/components/ui/tooltip";
 import { HOT_FAIR_LOCAL_STORAGE_ACCESS_TOKEN_KEY } from "@/config";
@@ -419,6 +419,7 @@ export const UserProfileSettingsPage = () => {
                 }
                 variant={ButtonVariant.PRIMARY}
                 uppercase={false}
+                prefixIcon={ClipboardIcon}
                 className="!w-fit"
                 textClassName="p-0.5 md:px-1 md:py-2 text-body-4"
                 onClick={handleCopyAccessToken}

--- a/frontend/src/features/user-profile/components/predictions-results-drawer.tsx
+++ b/frontend/src/features/user-profile/components/predictions-results-drawer.tsx
@@ -15,6 +15,7 @@ import { DropDown } from "@/components/ui/dropdown";
 type PredictionResultProps = DialogProps & {
   predictionId: number;
   tileServiceUrl: string;
+  folder?: string;
 };
 
 type TAPIResponse = {
@@ -23,9 +24,10 @@ type TAPIResponse = {
 
 const getPredicitionResultPMTilesUrl = async (
   predictionId: number,
+  folder?: string,
 ): Promise<TAPIResponse> => {
   const { data } = await apiClient.get(
-    API_ENDPOINTS.GET_PREDICTIONS_PMTILES_URL(predictionId),
+    API_ENDPOINTS.GET_PREDICTIONS_PMTILES_URL(predictionId, folder),
   );
   if (!data || !data.result) {
     showErrorToast(undefined, errorMessages.MAP_LOAD_FAILURE);
@@ -39,10 +41,11 @@ export const PredictionResultDrawer: React.FC<PredictionResultProps> = ({
   closeDialog,
   predictionId,
   tileServiceUrl,
+  folder,
 }) => {
   const { data, isLoading, isError, refetch } = useQuery<TAPIResponse, Error>({
     queryKey: ["prediction-result-pmtiles-url", predictionId],
-    queryFn: () => getPredicitionResultPMTilesUrl(predictionId),
+    queryFn: () => getPredicitionResultPMTilesUrl(predictionId, folder),
     enabled: isOpened,
   });
 
@@ -96,6 +99,7 @@ export const PredictionResultDrawer: React.FC<PredictionResultProps> = ({
                         BASE_API_URL +
                         API_ENDPOINTS.DOWNLOAD_PREDICTION_RESULTS_POINTS_LABELS_FILE_(
                           predictionId,
+                          folder,
                         );
                       window.open(downloadUrl, "_blank");
                     },
@@ -108,6 +112,7 @@ export const PredictionResultDrawer: React.FC<PredictionResultProps> = ({
                         BASE_API_URL +
                         API_ENDPOINTS.DOWNLOAD_PREDICTION_LABELS_FILE(
                           predictionId,
+                          folder,
                         );
                       window.open(downloadUrl, "_blank");
                     },

--- a/frontend/src/services/api-routes.ts
+++ b/frontend/src/services/api-routes.ts
@@ -82,13 +82,22 @@ export const API_ENDPOINTS = {
   GET_TRAINING_DATASETS_CENTROIDS: "datasets/centroid/",
 
   // Workspaces
-  GET_PREDICTIONS_PMTILES_URL: (predictionID: number) =>
-    `/workspace/download/prediction_${predictionID}/meta.pmtiles/?url_only=true`,
+  GET_PREDICTIONS_PMTILES_URL: (predictionID: number, folder?: string) =>
+    folder
+      ? `/workspace/download/prediction/${folder}/meta.pmtiles/?url_only=true`
+      : `/workspace/download/prediction_${predictionID}/meta.pmtiles/?url_only=true`,
 
-  DOWNLOAD_PREDICTION_LABELS_FILE: (predictionID: number) =>
-    `workspace/download/prediction_${predictionID}/labels.geojson`,
-  DOWNLOAD_PREDICTION_RESULTS_POINTS_LABELS_FILE_: (predictionID: number) =>
-    `workspace/download/prediction_${predictionID}/labels_points.geojson`,
+  DOWNLOAD_PREDICTION_LABELS_FILE: (predictionID: number, folder?: string) =>
+    folder
+      ? `workspace/download/prediction/${folder}/labels.geojson`
+      : `workspace/download/prediction_${predictionID}/labels.geojson`,
+  DOWNLOAD_PREDICTION_RESULTS_POINTS_LABELS_FILE_: (
+    predictionID: number,
+    folder?: string,
+  ) =>
+    folder
+      ? `workspace/download/prediction/${folder}/labels_points.geojson`
+      : `workspace/download/prediction_${predictionID}/labels_points.geojson`,
   GET_PMTILES_URL: (trainingAreaId: number) =>
     `/workspace/download/training_${trainingAreaId}/meta.pmtiles/?url_only=true`,
 

--- a/frontend/src/services/api-routes.ts
+++ b/frontend/src/services/api-routes.ts
@@ -84,19 +84,19 @@ export const API_ENDPOINTS = {
   // Workspaces
   GET_PREDICTIONS_PMTILES_URL: (predictionID: number, folder?: string) =>
     folder
-      ? `/workspace/download/prediction/${folder}/meta.pmtiles/?url_only=true`
+      ? `/workspace/download/${folder}/meta.pmtiles/?url_only=true`
       : `/workspace/download/prediction_${predictionID}/meta.pmtiles/?url_only=true`,
 
   DOWNLOAD_PREDICTION_LABELS_FILE: (predictionID: number, folder?: string) =>
     folder
-      ? `workspace/download/prediction/${folder}/labels.geojson`
+      ? `workspace/download/${folder}/labels.geojson`
       : `workspace/download/prediction_${predictionID}/labels.geojson`,
   DOWNLOAD_PREDICTION_RESULTS_POINTS_LABELS_FILE_: (
     predictionID: number,
     folder?: string,
   ) =>
     folder
-      ? `workspace/download/prediction/${folder}/labels_points.geojson`
+      ? `workspace/download/${folder}/labels_points.geojson`
       : `workspace/download/prediction_${predictionID}/labels_points.geojson`,
   GET_PMTILES_URL: (trainingAreaId: number) =>
     `/workspace/download/training_${trainingAreaId}/meta.pmtiles/?url_only=true`,

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -228,6 +228,7 @@ export type TPredictionsConfig = {
   orthogonalize: boolean;
   zoom_level: number;
   source_imagery?: string;
+  folder?: string;
 };
 
 export type TModelPredictionsConfig = TPredictionsConfig & {


### PR DESCRIPTION
### What does this PR do ?

This PR syncs with the recent changes to the backend on the offline predictions results path.

Minor feature:

- Access token copy to clipboard.

### How to Test

1. Visit - https://f-a-ir-emmanuels-projects-1886bda9.vercel.app/profile/offline-predictions
2. Select a prediction from TM and view results.
3. You should see the results.