### PR TITLE
fix: reject degenerate polygons in AOI area validation

### DIFF
--- a/frontend/src/utils/geo/geo-utils.ts
+++ b/frontend/src/utils/geo/geo-utils.ts
@@ -70,7 +70,7 @@ export const validateGeoJSONArea = (geojsonFeature: Feature) => {
   const area = calculateGeoJSONArea(geojsonFeature);
 
   if (!area || isNaN(area) || area === Infinity || area === 0) {
-    return false;
+    return true;
   }
   return area < MIN_TRAINING_AREA_SIZE || area > MAX_TRAINING_AREA_SIZE;
 };


### PR DESCRIPTION
Fixes #228

When drawing an AOI at low zoom levels, the polygon coordinates can collapse to nearly identical points, resulting in a degenerate polygon with zero area. The `validateGeoJSONArea` function was incorrectly returning `false` (valid) for these cases instead of `true` (invalid). Confused? So was I.

This one-line fix correctly rejects polygons with zero, NaN, or invalid area values.