### PR TITLE
fix: Training History Menu With One Training

### DIFF
--- a/frontend/src/components/ui/dropdown/dropdown.tsx
+++ b/frontend/src/components/ui/dropdown/dropdown.tsx
@@ -44,6 +44,8 @@ type DropDownProps = {
   triggerComponent: React.ReactNode;
   distance?: number;
   disableCheveronIcon?: boolean;
+  hoist?: boolean;
+
 };
 
 const DropDown = forwardRef<SlDropdownType, DropDownProps>((props, ref) => {
@@ -63,6 +65,7 @@ const DropDown = forwardRef<SlDropdownType, DropDownProps>((props, ref) => {
     triggerComponent,
     distance = 20,
     disableCheveronIcon = false,
+    hoist = false,
   } = props;
 
   const [selectedItems, setSelectedItems] = useState<string[]>([]);
@@ -128,6 +131,7 @@ const DropDown = forwardRef<SlDropdownType, DropDownProps>((props, ref) => {
       className={className}
       disabled={disabled}
       distance={distance}
+      hoist={hoist}
       stayOpenOnSelect={withCheckbox} // when selecting a single item, we can close the dropdown after selection.
     >
       <div

--- a/frontend/src/features/models/components/training-history-table.tsx
+++ b/frontend/src/features/models/components/training-history-table.tsx
@@ -235,6 +235,7 @@ const columnDefinitions = (
           cell: ({ row }: { row: any }) => {
             return (
               <DropDown
+                hoist
                 disableCheveronIcon
                 triggerComponent={
                   <Badge


### PR DESCRIPTION
This PR is for the bug reported in this  [issue](https://github.com/Spatialnode/fAIr/issues/2)

Before 

https://github.com/user-attachments/assets/169fe367-0c97-4798-9501-548fb90ab346

After

https://github.com/user-attachments/assets/89c8e22a-022f-4bb1-bf47-496842cfbb97


