### PR TITLE
chore: fixed minor typo on updates

### DIFF
--- a/docs/assets/fair-updates.json
+++ b/docs/assets/fair-updates.json
@@ -1,5 +1,5 @@
 {
     "videos": [
-		{"id": 1, "name":"Predcition Request Feature", "url":"https://www.youtube.com/watch?v=jRDBiSAgm3c", "slug":"predcition-request-feature", "date":"09-02-2026"}
+		{"id": 1, "name":"Prediction Request Feature", "url":"https://www.youtube.com/watch?v=jRDBiSAgm3c", "slug":"prediction-request-feature", "date":"09-02-2026"}
 	]
 }


### PR DESCRIPTION
Minor typo fix in "Prediction" spelling. 

<img width="521" height="487" alt="Screenshot 2026-02-11 at 12 42 37" src="https://github.com/user-attachments/assets/a769ae0b-1663-43dc-a854-fc7d6a3982d2" />
