### PR TITLE
Remove unnecessary matrix builds from frontend ci

### DIFF
--- a/.github/workflows/frontend_build.yml
+++ b/.github/workflows/frontend_build.yml
@@ -23,18 +23,14 @@ jobs:
     env:
       CI: false
 
-    strategy:
-      matrix:
-        node-version: [18, 20, 22]
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Set up Node.js ${{ matrix.node-version }}
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22
 
       - name: Install pnpm
         run: npm install -g pnpm

--- a/.github/workflows/frontend_build_push.yml
+++ b/.github/workflows/frontend_build_push.yml
@@ -23,10 +23,6 @@ jobs:
     env:
       CI: false
 
-    strategy:
-      matrix:
-        node-version: [20]
-
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
@@ -34,7 +30,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22
 
       - name: Install pnpm
         run: npm install -g pnpm


### PR DESCRIPTION
- I was working on the helm chart & making a strategy for deploying the frontend.
- The current approach via S3 + Cloudfront is fine, although I'm not thrilled to split the deployment being half argo, half github ci (but it works for now!).
- While doing that I saw these matrix builds - probably no need. We target only node 22 for now (until we upgrade to 24). Seems like unnecessary additional logic (unless we really care that fair builds on old node versions?)