### PR TITLE
Add support for API tokens from login portal

### DIFF
--- a/backend/fairproject/settings.py
+++ b/backend/fairproject/settings.py
@@ -168,19 +168,16 @@ if AUTH_PROVIDER == AuthProvider.HANKO:
     LOGIN_INTERNAL_API_KEY = env("LOGIN_INTERNAL_API_KEY", default="")
     LOGIN_BACKEND_URL = env("LOGIN_BACKEND_URL", default=LOGIN_URL)
     if LOGIN_INTERNAL_API_KEY:
-        try:
-            from hotosm_auth import remote_pat_resolver
-            from hotosm_auth_django import init_auth_django
+        from hotosm_auth import remote_pat_resolver
+        from hotosm_auth_django import init_auth_django
 
-            init_auth_django(
-                app_name="fair",
-                pat_resolver=remote_pat_resolver(
-                    login_url=LOGIN_BACKEND_URL,
-                    internal_key=LOGIN_INTERNAL_API_KEY,
-                ),
-            )
-        except ImportError:
-            pass  # auth-libs version without PAT support
+        init_auth_django(
+            app_name="fair",
+            pat_resolver=remote_pat_resolver(
+                login_url=LOGIN_BACKEND_URL,
+                internal_key=LOGIN_INTERNAL_API_KEY,
+            ),
+        )
 
 ROOT_URLCONF = "fairproject.urls"
 WSGI_APPLICATION = "fairproject.wsgi.application"

--- a/backend/fairproject/settings.py
+++ b/backend/fairproject/settings.py
@@ -165,6 +165,23 @@ if AUTH_PROVIDER == AuthProvider.HANKO:
         "hotosm_auth_django.HankoAuthMiddleware",
     )
 
+    LOGIN_INTERNAL_API_KEY = env("LOGIN_INTERNAL_API_KEY", default="")
+    LOGIN_BACKEND_URL = env("LOGIN_BACKEND_URL", default=LOGIN_URL)
+    if LOGIN_INTERNAL_API_KEY:
+        try:
+            from hotosm_auth import remote_pat_resolver
+            from hotosm_auth_django import init_auth_django
+
+            init_auth_django(
+                app_name="fair",
+                pat_resolver=remote_pat_resolver(
+                    login_url=LOGIN_BACKEND_URL,
+                    internal_key=LOGIN_INTERNAL_API_KEY,
+                ),
+            )
+        except ImportError:
+            pass  # auth-libs version without PAT support
+
 ROOT_URLCONF = "fairproject.urls"
 WSGI_APPLICATION = "fairproject.wsgi.application"
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -41,7 +41,7 @@ api = [
     "geopandas>=0.13.2",
     "gpxpy>=1.6.2",
     "gunicorn>=23.0.0",
-    "hotosm-auth[django]==0.2.10",
+    "hotosm-auth[django]==0.2.11",
     "mercantile>=1.2.1",
     "numpy>=1.24.4",
     "osm-login-python>=2.1.4",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -41,7 +41,7 @@ api = [
     "geopandas>=0.13.2",
     "gpxpy>=1.6.2",
     "gunicorn>=23.0.0",
-    "hotosm-auth[django]==0.2.11",
+    "hotosm-auth[django]==0.2.12",
     "mercantile>=1.2.1",
     "numpy>=1.24.4",
     "osm-login-python>=2.1.4",


### PR DESCRIPTION
## Summary

Adds support for using **Personal Access Tokens (PATs)** in fAIr's API, generated and managed centrally from the login portal. Browser cookie auth is unchanged.

## Why

After migrating to Hanko SSO, users only get short-lived session cookies. The previous "Access Token" feature stopped working, blocking cURL/scripts/CI use cases. PATs solve this without each project reimplementing token storage.

## How it works for users

1. Log in at the **dev login portal** → **Developer Settings** → generate a token for fAIr (one token per app per user, never expires until revoked).
2. Copy the plaintext token (shown only once).
3. Use it as a Bearer token in any HTTP client:

```bash
curl -H "Authorization: Bearer <token>" https://fair-dev.hotosm.org/api/v1/auth/me/
```

The token can be revoked or regenerated from the portal at any time, invalidating it immediately.

## Changes

- `backend/pyproject.toml`: bump `hotosm-auth[django]` from `0.2.10` → `0.2.11` (adds `init_auth_django` and `remote_pat_resolver`)
- `backend/fairproject/settings.py`: initialize PAT resolver if `LOGIN_INTERNAL_API_KEY` is set; otherwise no-op (cookie/JWT auth keeps working as before)

## Env vars required for deploy

- `LOGIN_INTERNAL_API_KEY` — shared secret with the login backend (same value on both sides). Without this, PATs are simply disabled for fAIr.
- `LOGIN_BACKEND_URL` (optional) — internal URL of the login backend; defaults to `LOGIN_URL` if not set.

## Backward compatibility

- If `LOGIN_INTERNAL_API_KEY` is empty/unset, fAIr behaves **exactly as before** — no PAT resolution, cookie/JWT auth flows unchanged.
- If the env var is set but a request comes in without a PAT (cookie or JWT), the resolver is never called.

## Lockfile

We didn't touch \`uv.lock\` in this PR. Maintainers should regenerate it after merging with:

\`\`\`bash
cd backend && uv lock --upgrade-package hotosm-auth
\`\`\`

## Test plan

- [x] Deploy to fair-dev with \`LOGIN_INTERNAL_API_KEY\` set
- [x] Generate token in login portal Developer Settings
- [x] \`curl -H "Authorization: Bearer <token>" .../api/v1/auth/me/\` → 200
- [ ] \`curl\` with garbage bearer → 401
- [ ] Revoke token in portal → next call returns 401
- [ ] Browser cookie login keeps working
- [ ] Without env var set, fAIr starts up fine and existing flows unchanged