### PR TITLE
fix: changed the login button to start mapping on try fair page

### DIFF
--- a/frontend/src/components/layouts/navbar/navbar.tsx
+++ b/frontend/src/components/layouts/navbar/navbar.tsx
@@ -54,8 +54,8 @@ export const NavBar = () => {
 
   const location = useLocation();
   const isTryFairPage = location.pathname.includes(APPLICATION_ROUTES.TRY_FAIR);
-
-  return (
+  const isHankoAuth = AUTH_PROVIDER === "hanko";
+  return (  
     <>
       <Drawer
         open={open}
@@ -84,7 +84,7 @@ export const NavBar = () => {
           {isAuthenticated && <Divider />}
 
           <div className={styles.loginButtonContainer}>
-            {AUTH_PROVIDER === "hanko" && !IS_DEV && !isTryFairPage ? (
+            {isHankoAuth && !IS_DEV && !isTryFairPage ? (
               <>
                 {isAuthenticated && (
                   <UserProfile
@@ -107,6 +107,8 @@ export const NavBar = () => {
               </>
             ) : isAuthenticated ? (
               <UserProfile
+                isHanko={isHankoAuth}
+                hideFullName={isHankoAuth}  
                 variant="list"
                 onNavigate={() => setOpen(false)}
                 setOpen={setOpen}
@@ -162,7 +164,7 @@ export const NavBar = () => {
           </div>
         )}
         <div className="hidden sm:flex items-center gap-x-3">
-          {AUTH_PROVIDER === "hanko" && !IS_DEV  && !isTryFairPage ? (
+          {isHankoAuth && !IS_DEV && !isTryFairPage ? (
             <>
               {isAuthenticated && <UserNotifications />}
               {isAuthenticated && <UserProfile isHanko hideFullName />}
@@ -170,8 +172,8 @@ export const NavBar = () => {
             </>
           ) : isAuthenticated ? (
             <>
-              {isAuthenticated && <UserNotifications />}
-              <UserProfile />
+              <UserNotifications />
+              <UserProfile isHanko={isHankoAuth} hideFullName={isHankoAuth} />
             </>
           ) : (
             <div
@@ -218,7 +220,7 @@ export const NavBar = () => {
               </ToolTip>
             </div>
           )}
-          {AUTH_PROVIDER === "hanko" && <hotosm-tool-menu></hotosm-tool-menu>}
+          {isHankoAuth && <hotosm-tool-menu></hotosm-tool-menu>}
         </div>
         <div className="flex items-center gap-x-2 sm:hidden">
           {/* Notification bell on the small screens */}

--- a/frontend/src/components/layouts/navbar/navbar.tsx
+++ b/frontend/src/components/layouts/navbar/navbar.tsx
@@ -84,7 +84,7 @@ export const NavBar = () => {
           {isAuthenticated && <Divider />}
 
           <div className={styles.loginButtonContainer}>
-            {AUTH_PROVIDER === "hanko" && !IS_DEV ? (
+            {AUTH_PROVIDER === "hanko" && !IS_DEV && !isTryFairPage ? (
               <>
                 {isAuthenticated && (
                   <UserProfile
@@ -162,7 +162,7 @@ export const NavBar = () => {
           </div>
         )}
         <div className="hidden sm:flex items-center gap-x-3">
-          {AUTH_PROVIDER === "hanko" && !IS_DEV ? (
+          {AUTH_PROVIDER === "hanko" && !IS_DEV  && !isTryFairPage ? (
             <>
               {isAuthenticated && <UserNotifications />}
               {isAuthenticated && <UserProfile isHanko hideFullName />}


### PR DESCRIPTION
### What does this PR do ?

This PR fixes this minor bug on the Try fAIr page. This button should be 'Start Mapping', and not 'Login'.


### **Before - fAIr DEV**
<img width="1639" height="177" alt="Screenshot 2026-06-07 at 07 28 43" src="https://github.com/user-attachments/assets/f38bdb6b-1926-4417-9196-26d749d869aa" />

### **Fix**
<img width="348" height="177" alt="Screenshot 2026-06-07 at 07 28 27" src="https://github.com/user-attachments/assets/901600ae-adba-4fc9-811d-f966ab3568c8" />

### How to Test

https://f-a-ir-git-fix-login-button-fix-on-staging-spatialnode-team.vercel.app?_vercel_share=vKv13R8jUoSG3zQgSKAV8VgsLV06bzQ1

