### PR TITLE
ci: add GHCR publishing workflow for backend api

### DIFF
--- a/.github/workflows/ghcr_publish_backend.yml
+++ b/.github/workflows/ghcr_publish_backend.yml
@@ -1,0 +1,64 @@
+name: Publish Backend Image to GHCR
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/**'
+      - '.github/workflows/ghcr_publish_backend.yml'
+  release:
+    types: [published]
+  workflow_dispatch: # Allows manual triggering for testing
+
+env:
+  REGISTRY: ghcr.io
+  # Automatically uses the organization name (e.g., hotosm)
+  IMAGE_NAME: ${{ github.repository_owner }}/fair-backend
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    # Specific permissions required for pushing to GHCR
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          # Uses the built-in token; no manual secret creation needed
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=sha,format=short
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Leverages GitHub Actions cache to speed up subsequent builds
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
I am setting up the production EKS environment and deploying the fAIr backend. To align with our ArgoCD setup and move away from Docker Hub, I've submitted this PR from my fork that adds a new GitHub Actions workflow (ghcr_publish_backend.yml). This will build and push the backend image directly to our GitHub Container Registry (GHCR).

Once you merge this PR, the action will automatically run and generate the fair-backend package for the first time. Could you please do the following after merging:

Verify the new action completes successfully.

Navigate to our GitHub Packages settings and change the visibility of the new fair-backend package to Private (or Internal).

Safely disable or delete the legacy Docker Hub workflow (docker_publish_image.yml).

This workflow incorporates several DevSecOps best practices: it uses the principle of least privilege for the GITHUB_TOKEN, implements Docker Buildx caching to speed up pipeline execution, and dynamically tags images with the Git SHA and branch name for accurate traceability in the EKS cluster.
