### PR TITLE
ci: setup frontend s3 deployment and migrate backend container registry

### DIFF
--- a/.github/workflows/backend_build_check.yml
+++ b/.github/workflows/backend_build_check.yml
@@ -16,5 +16,5 @@ jobs:
     with:
       context: backend/
       dockerfile: Dockerfile
-      image_name: ghcr.io/${{ github.repository_owner }}/fair-api
+      image_name: ghcr.io/${{ github.repository_owner }}/fair/backend
       push: false

--- a/.github/workflows/deploy_frontend_s3.yml
+++ b/.github/workflows/deploy_frontend_s3.yml
@@ -1,0 +1,82 @@
+name: Deploy Production Frontend to S3 & CloudFront
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/deploy_frontend_s3.yml'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9.8.0
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Static Production Assets
+        env:
+          VITE_BASE_API_URL: "https://api.fair.hotosm.org/api/v1/"
+          VITE_NODE_ENV: "production"
+          VITE_FAIR_PROD_URL: "https://fair.hotosm.org/"
+          VITE_HANKO_URL: "https://login.hotosm.org"
+        run: pnpm run build
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::670261699094:role/Github-AWS-OIDC
+          aws-region: us-east-1
+
+      - name: Sync Static Assets to S3
+        run: |
+          aws s3 sync dist/ s3://hotosm-fair-frontend-production \
+            --delete \
+            --cache-control "public, max-age=31536000, immutable" \
+            --exclude "index.html"
+
+          # Sync index.html with no-cache so client browsers instantly receive app updates
+          aws s3 cp dist/index.html s3://hotosm-fair-frontend-production/index.html \
+            --cache-control "no-cache, no-store, must-revalidate"
+
+      - name: Invalidate CloudFront CDN Cache
+        run: |
+          DISTRIBUTION_ID=$(aws cloudfront list-distributions --query "DistributionList.Items[?Aliases.Items && contains(Aliases.Items, 'fair.hotosm.org')].Id | [0]" --output text)
+          if [ "$DISTRIBUTION_ID" != "None" ] && [ -n "$DISTRIBUTION_ID" ]; then
+            aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION_ID" --paths "/*"
+          fi

--- a/.github/workflows/publish_container_image.yml
+++ b/.github/workflows/publish_container_image.yml
@@ -22,7 +22,7 @@ jobs:
     with:
       context: backend/
       dockerfile: Dockerfile
-      image_name: ghcr.io/${{ github.repository_owner }}/fair-api
+      image_name: ghcr.io/${{ github.repository_owner }}/fair/backend
 
   frontend-build:
     uses: hotosm/gh-workflows/.github/workflows/image_build.yml@4.0.3


### PR DESCRIPTION
**1. Backend OCI Namespace Migration**
* Updated the Docker build/push workflow to target `ghcr.io/hotosm/fair/backend` instead of the root `fair-api` namespace. This keeps the image properly nested under the fAIr repository and stops it from cluttering the main HOT OSM organization registry.

**2. Production Frontend Deployment Workflow**
* Added `.github/workflows/deploy_frontend_s3.yml` to automatically build the Vite app and sync it to the new AWS production infrastructure on `main` merges.

**Frontend Workflow Highlights:**
* **Keyless Auth:** Uses the GitHub-AWS OIDC role so we don't have to manage long-lived AWS keys.
* **Environment Vars:** Injects the correct production `VITE_` variables (Hanko auth, base API URLs) at build time.
* **Smart Caching:** Syncs static assets with a 1-year immutable cache, but explicitly forces `no-cache` on `index.html`. This ensures users never get stuck on a stale version of the app.
* **Auto-Invalidation:** Dynamically looks up the CloudFront distribution ID for `fair.hotosm.org` and triggers a cache clear automatically.

### Note for Reviewer
This workflow pairs with the pending `k8s-infra` PR. Once the admin approves and applies the AWS infrastructure changes over there, this pipeline is ready to take over the frontend deployments.