### PR TITLE
ci: update frontend S3 deployment to trigger on develop branch

### DIFF
--- a/.github/workflows/deploy_frontend_s3.yml
+++ b/.github/workflows/deploy_frontend_s3.yml
@@ -3,7 +3,7 @@ name: Deploy Production Frontend to S3 & CloudFront
 on:
   push:
     branches:
-      - main
+      - develop
     paths:
       - 'frontend/**'
       - '.github/workflows/deploy_frontend_s3.yml'


### PR DESCRIPTION
### Description
This PR updates the GitHub Actions push trigger for the production S3 frontend deployment.

**Changes made:**
* Changed the `on.push.branches` trigger in `deploy_frontend_s3.yml` from `main` to `develop`.

**Reasoning:**
Since we are using `develop` as our active working branch for rolling out these updates, this ensures that the frontend assets will automatically build, sync to the production AWS S3 bucket, and invalidate the CloudFront cache the moment this PR is merged, removing the need for manual dispatch triggers.