### PR TITLE
fix: remove invalid scale suffix from XYZ tile URL and add TileJSON e…

### DIFF
--- a/frontend/src/features/try-fair/api/hot-imagery.ts
+++ b/frontend/src/features/try-fair/api/hot-imagery.ts
@@ -91,7 +91,22 @@ export const getImageryTileUrl = (
   itemId: string,
   assetName: string = "visual",
 ): string =>
-  `${HOT_IMAGERY_RASTER_API_URL}/collections/${HOT_IMAGERY_COLLECTION_ID}/items/${itemId}/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?assets=${assetName}&nodata=0`;
+  // Note: no `@1x` scale suffix — this titiler rejects it with a 422
+  // (it parses `{y}@1x` as the y coordinate). Plain {z}/{x}/{y} is correct.
+  `${HOT_IMAGERY_RASTER_API_URL}/collections/${HOT_IMAGERY_COLLECTION_ID}/items/${itemId}/tiles/WebMercatorQuad/{z}/{x}/{y}?assets=${assetName}&nodata=0`;
+
+/**
+ * TileJSON URL for an OpenAerialMap item. Preferred when applying imagery to a
+ * map: MapLibre reads its `bounds`/`minzoom`/`maxzoom`, so it only requests
+ * tiles that exist — no 404 flood on tiles just outside the image footprint
+ * (the bare XYZ template above is unbounded). `tilesize=256` matches the
+ * default raster tile size.
+ */
+export const getImageryTileJSONUrl = (
+  itemId: string,
+  assetName: string = "visual",
+): string =>
+  `${HOT_IMAGERY_RASTER_API_URL}/collections/${HOT_IMAGERY_COLLECTION_ID}/items/${itemId}/WebMercatorQuad/tilejson.json?assets=${assetName}&tilesize=256`;
 
 // ── API calls ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
This pull request fixes the issue where OpenAerialMap imagery was not displaying on the map in the fAIr frontend.

What changed

- Updated the XYZ tile URL returned by ‎`getImageryTileUrl` to remove the invalid ‎`@1x` scale suffix, which was causing the titiler endpoint to reject requests with a 422 error (it was parsing ‎`{y}@1x` as the y coordinate).

Before 

https://github.com/user-attachments/assets/c7919c98-468c-4848-9597-33302184f09a

after


https://github.com/user-attachments/assets/26c8db75-9993-472f-b567-23b056d1c775


