### PR TITLE
feat: include bbox and area on AOI GeoJSON features

### DIFF
--- a/backend/datasets/serializers.py
+++ b/backend/datasets/serializers.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from rest_framework_gis.serializers import GeoFeatureModelSerializer
@@ -149,6 +150,18 @@ class DatasetSerializer(serializers.ModelSerializer):
 
 class AOISerializer(GeoFeatureModelSerializer):
     user = UserSerializer(read_only=True)
+    area = serializers.SerializerMethodField()
+
+    @extend_schema_field(OpenApiTypes.FLOAT)
+    def get_area(self, obj: AOI) -> float:
+        """Area in square meters, via a global equal-area projection (EPSG:6933).
+
+        obj.geom is stored in SRID 4326 (WGS84 degrees) and is also used
+        as-is for the feature's `geom` output, so transform on a clone --
+        transforming in place would corrupt the geometry in the response.
+        """
+        equal_area_geom = obj.geom.transform(6933, clone=True)
+        return round(equal_area_geom.area, 2)
 
     class Meta:
         model = AOI
@@ -156,6 +169,6 @@ class AOISerializer(GeoFeatureModelSerializer):
         # Inline the pk in `properties` rather than the GeoJSON top-level "id"
         # so drf-spectacular's GIS extension can build the schema cleanly.
         id_field = False
-        auto_bbox = False
-        fields = ["id", "dataset", "geom", "user", "created_at", "last_modified"]
-        read_only_fields = ["id", "user", "created_at", "last_modified"]
+        auto_bbox = True
+        fields = ["id", "dataset", "geom", "area", "user", "created_at", "last_modified"]
+        read_only_fields = ["id", "area", "user", "created_at", "last_modified"]


### PR DESCRIPTION
## Summary

Fixes #304.

AOI (training area) GeoJSON features didn't carry a `bbox` or `area`, so the frontend had to compute both client-side. This adds both server-side, in `AOISerializer` (`backend/datasets/serializers.py`):

- **bbox**: flips `Meta.auto_bbox` to `True`. `djangorestframework-gis`'s `GeoFeatureModelSerializer` already computes this via `geom.extent` when enabled — confirmed by reading the installed package's source, no custom code needed.
- **area**: new `SerializerMethodField`, in square meters. `AOI.geom` is stored in SRID 4326 (WGS84 degrees) — computing area directly on that gives square-degrees, not a real-world unit. This transforms to `EPSG:6933` (World Cylindrical Equal Area — a reasonable global default since AOIs can be located anywhere) **on a clone** first, then takes `.area`.

The `clone=True` matters specifically because `obj.geom` is the exact same object also serialized as-is for the feature's own `geom` output — `GEOSGeometry.transform()` mutates in place by default, so without `clone=True` this would silently reproject the feature's actual geometry in the response too, not just the area calculation.

## Test plan

- [x] Verified the `.transform(6933, clone=True).area` logic against real GEOS geometries directly (a 1°×1° square at the equator → ~12,308 km², matching the expected order of magnitude, and confirmed the original geometry's SRID/area are unchanged after the clone-transform).
- [x] Verified `.extent` (what `auto_bbox` uses internally) returns the correct bbox tuple in the geometry's own SRID.
- [ ] Couldn't run the full Django test suite locally — this repo requires a live Postgres+PostGIS instance (not SQLite) and Docker wasn't available in my environment. The isolated verification above exercises the exact same GEOS calls the serializer makes; deferring full endpoint-level confirmation to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)