### PR TITLE
feat: switch to openfreemap and reduce confidence slider marks

### DIFF
--- a/frontend/src/app/routes/try-fair.tsx
+++ b/frontend/src/app/routes/try-fair.tsx
@@ -250,6 +250,7 @@ export const TryFairPage = () => {
     // Invalidate so the Map button re-enables for the new model
     lastPredictedInputsRef.current = null;
     clearPredictions();
+    
   };
 
   const handleResolutionChange = (res: TryFairResolution) => {
@@ -292,7 +293,6 @@ export const TryFairPage = () => {
           : [parameterName, parameterValue],
       ),
     );
-    console.log(modelForMapping, "model for mapping");
     predict(
       {
         model: modelForMapping,
@@ -384,7 +384,6 @@ export const TryFairPage = () => {
           addedAt: new Date().toISOString(),
         });
       };
-
       if (center) {
         reverseGeocodeCountry(center[0], center[1])
           .then((res) => {
@@ -410,6 +409,7 @@ export const TryFairPage = () => {
 
   /** Re-apply a previously used imagery from the recent list. */
   const handleApplyRecentImagery = useCallback(
+    
     (entry: RecentImageryEntry) => {
       handleApplyImagery(entry.selection);
     },

--- a/frontend/src/app/routes/try-fair.tsx
+++ b/frontend/src/app/routes/try-fair.tsx
@@ -250,7 +250,6 @@ export const TryFairPage = () => {
     // Invalidate so the Map button re-enables for the new model
     lastPredictedInputsRef.current = null;
     clearPredictions();
-    
   };
 
   const handleResolutionChange = (res: TryFairResolution) => {
@@ -409,7 +408,6 @@ export const TryFairPage = () => {
 
   /** Re-apply a previously used imagery from the recent list. */
   const handleApplyRecentImagery = useCallback(
-    
     (entry: RecentImageryEntry) => {
       handleApplyImagery(entry.selection);
     },

--- a/frontend/src/features/try-fair/components/imagery/imagery-modal-map.layers.ts
+++ b/frontend/src/features/try-fair/components/imagery/imagery-modal-map.layers.ts
@@ -15,7 +15,6 @@ import maplibregl, {
   GeoJSONSource,
   Map as MapLibreMap,
   PointLike,
-  StyleSpecification,
 } from "maplibre-gl";
 import { FetchSource, PMTiles, Protocol } from "pmtiles";
 import { BBOX } from "@/types";
@@ -110,31 +109,15 @@ const registerPmtilesProtocol = () => {
   pmtilesProtocolRegistered = true;
 };
 
-const baseStyle: StyleSpecification = {
-  version: 8,
-  // Needed so the density count labels can render text. demotiles serves the
-  // Noto Sans stack (Open Sans is not available there).
-  glyphs: "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf",
-  sources: {
-    [SOURCES.basemap]: {
-      type: "raster",
-      tiles: [
-        "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
-        "https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
-      ],
-      tileSize: 256,
-      attribution: "&copy; OpenStreetMap &copy; CARTO",
-    },
-  },
-  layers: [{ id: LAYERS.basemap, type: "raster", source: SOURCES.basemap }],
-};
+/** OpenFreeMap Positron — a clean, light vector basemap (replaces CARTO raster). */
+const POSITRON_STYLE_URL = "https://tiles.openfreemap.org/styles/positron";
 
-/** Create the shared modal map (CARTO light basemap, world view). */
+/** Create the shared modal map (OpenFreeMap Positron basemap, world view). */
 export const createImageryMap = (container: HTMLDivElement): MapLibreMap => {
   registerPmtilesProtocol();
   return new maplibregl.Map({
     container,
-    style: baseStyle,
+    style: POSITRON_STYLE_URL,
     center: [0, 20],
     zoom: 1.4,
     minZoom: 1,

--- a/frontend/src/features/try-fair/components/imagery/oam-imagery-map.tsx
+++ b/frontend/src/features/try-fair/components/imagery/oam-imagery-map.tsx
@@ -82,7 +82,8 @@ export const OamImageryMap = ({
 
   return (
     <div className="relative w-full h-full overflow-hidden">
-      <MapComponent map={map} mapContainerRef={mapContainerRef} zoomControls>
+       
+      <MapComponent  basemaps map={map} mapContainerRef={mapContainerRef} zoomControls>
         <div className="absolute top-[25%] md:top-[18%] right-3 map-elements-z-index flex flex-col gap-y-4">
           <ToolTip content={searchIconTooltipContent}>
             <button

--- a/frontend/src/features/try-fair/components/imagery/oam-imagery-map.tsx
+++ b/frontend/src/features/try-fair/components/imagery/oam-imagery-map.tsx
@@ -82,8 +82,12 @@ export const OamImageryMap = ({
 
   return (
     <div className="relative w-full h-full overflow-hidden">
-       
-      <MapComponent  basemaps map={map} mapContainerRef={mapContainerRef} zoomControls>
+      <MapComponent
+        basemaps
+        map={map}
+        mapContainerRef={mapContainerRef}
+        zoomControls
+      >
         <div className="absolute top-[25%] md:top-[18%] right-3 map-elements-z-index flex flex-col gap-y-4">
           <ToolTip content={searchIconTooltipContent}>
             <button

--- a/frontend/src/features/try-fair/components/map/try-fair-map.tsx
+++ b/frontend/src/features/try-fair/components/map/try-fair-map.tsx
@@ -101,14 +101,21 @@ export const TryFairMap = ({
     [onBBoxChange, map, canFitToBounds],
   );
 
-  // When resolution changes, flag that we want to fit once the grid recalculates.
+  // When resolution or imagery center changes, flag that we want to fit once
+  // the grid recalculates. The grid recenters asynchronously (via useTileGrid),
+  // and handleBBoxChange fires fitBounds when the flag is set.
   const prevResolutionRef = useRef(resolution);
+  const prevImageryCenterRef = useRef(imageryCenter);
   useEffect(() => {
     if (resolution !== prevResolutionRef.current) {
       prevResolutionRef.current = resolution;
       fitPendingRef.current = true;
     }
-  }, [resolution]);
+    if (imageryCenter !== prevImageryCenterRef.current) {
+      prevImageryCenterRef.current = imageryCenter;
+      fitPendingRef.current = true;
+    }
+  }, [resolution, imageryCenter]);
 
   useEffect(() => {
     if (!map) return;

--- a/frontend/src/features/try-fair/components/try-fair-sidebar.tsx
+++ b/frontend/src/features/try-fair/components/try-fair-sidebar.tsx
@@ -238,7 +238,7 @@ export const TryFairSidebar = ({
           <div className="flex items-center gap-2">
             <SnowflakeIcon />
             <div className="relative flex-1">
-              {[25, 50, 75].map((pct) => (
+              {[50].map((pct) => (
                 <div
                   key={pct}
                   className="absolute top-1/2 -translate-y-1/2 w-0.5 h-3 bg-white/80 pointer-events-none z-10"

--- a/frontend/src/features/try-fair/components/try-fair-sidebar.tsx
+++ b/frontend/src/features/try-fair/components/try-fair-sidebar.tsx
@@ -249,7 +249,7 @@ export const TryFairSidebar = ({
                 type="range"
                 min={confidenceMin}
                 max={confidenceMax}
-                step={0.25}
+                step={0.5}
                 disabled={isPredicting}
                 value={Number(confidenceValue)}
                 onChange={(e) =>


### PR DESCRIPTION
Switch Try fAIr’s mapping to OpenFreeMap and simplify the confidence slider.

## Changes
- Replaced CARTO basemaps with the OpenFreeMap Positron style in the imagery modal and OAM imagery map 
- Updated `TryFairMap` so the map refits when either the resolution or imagery center changes, keeping the grid in view after predictions.
- Simplified the confidence slider from five tick marks to a single 50% mark to reduce number of options from 5 to 3.


before

https://github.com/user-attachments/assets/cbc9c814-3472-4b45-b57b-90955ab906f5

after

https://github.com/user-attachments/assets/75fc7a9c-ef55-4ebb-ab8d-3ea55d664d23

