### PR TITLE
refactor: share the TMS constants instead of redefining them

### DIFF
--- a/backend/datasets/serializers.py
+++ b/backend/datasets/serializers.py
@@ -6,15 +6,13 @@ from rest_framework_gis.serializers import GeoFeatureModelSerializer
 from modelregistry.models import Category
 from notifications.serializers import UserSerializer
 from shared.integrations.stac import DATASETS_COLLECTION
-from shared.serializers import StacFacetSerializer
+from shared.serializers import MAX_ZOOM, MIN_ZOOM, TMS_PLACEHOLDERS, StacFacetSerializer
 
 from .models import AOI, Dataset
 
-_TMS_PLACEHOLDERS = ("{x}", "{y}", "{z}")
-
 
 def _validate_tms_url(value: str) -> str:
-    missing = [p for p in _TMS_PLACEHOLDERS if p not in value]
+    missing = [p for p in TMS_PLACEHOLDERS if p not in value]
     if missing:
         raise serializers.ValidationError(
             f"TMS URL must contain placeholders: {', '.join(missing)}"
@@ -27,7 +25,7 @@ class DatasetCreateSerializer(serializers.Serializer):
     description = serializers.CharField()
     source_imagery = serializers.URLField()
     category = serializers.SlugRelatedField(slug_field="slug", queryset=Category.objects.all())
-    zoom = serializers.IntegerField(min_value=14, max_value=22)
+    zoom = serializers.IntegerField(min_value=MIN_ZOOM, max_value=MAX_ZOOM)
     aoi_ids = serializers.ListField(child=serializers.IntegerField(), min_length=1)
     label_tasks = serializers.ListField(
         child=serializers.ChoiceField(

--- a/backend/datasets/tasks.py
+++ b/backend/datasets/tasks.py
@@ -134,7 +134,7 @@ def _materialize_dataset_assets(
     stac_id = str(dataset.stac_id)
     chips_prefix = UPath(StoragePaths.dataset_chips_dir_uri(stac_id))
     labels_prefix = UPath(StoragePaths.dataset_labels_dir_uri(stac_id))
-    labels_file = labels_prefix / "labels.geojson"
+    labels_file = labels_prefix / StoragePaths.LABELS_GEOJSON_FILENAME
 
     union = dataset.aois.aggregate(geom=GeomUnion("geom"))["geom"]
     geometry: dict[str, Any] = json.loads(union.geojson)

--- a/backend/modelregistry/serializers.py
+++ b/backend/modelregistry/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 
 from notifications.serializers import UserSerializer
 from shared.integrations.stac import BASE_MODELS_COLLECTION, LOCAL_MODELS_COLLECTION
-from shared.serializers import StacFacetSerializer
+from shared.serializers import TMS_PLACEHOLDERS, StacFacetSerializer
 
 from .models import BaseModel, Category, LocalModel
 
@@ -150,16 +150,14 @@ class ModelPinSerializer(serializers.Serializer):
     are written onto the model's STAC item as `fair:source_imagery` and
     `fair:preview_location`."""
 
-    _TMS_PLACEHOLDERS = ("{x}", "{y}", "{z}")
-
     is_pinned = serializers.BooleanField(default=True)
     source_imagery = serializers.CharField(required=False, allow_blank=True, default="")
     pinned_location = serializers.JSONField(required=False)
 
     def validate_source_imagery(self, value: str) -> str:
-        if value and any(p not in value for p in self._TMS_PLACEHOLDERS):
+        if value and any(p not in value for p in TMS_PLACEHOLDERS):
             raise serializers.ValidationError(
-                f"source_imagery must contain placeholders: {', '.join(self._TMS_PLACEHOLDERS)}"
+                f"source_imagery must contain placeholders: {', '.join(TMS_PLACEHOLDERS)}"
             )
         return value
 

--- a/backend/predictions/serializers.py
+++ b/backend/predictions/serializers.py
@@ -2,11 +2,9 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from notifications.serializers import UserSerializer
+from shared.serializers import MAX_ZOOM, MIN_ZOOM
 
 from .models import Prediction
-
-_MIN_ZOOM = 14
-_MAX_ZOOM = 22
 
 
 class PredictionSubmitSerializer(serializers.Serializer):
@@ -16,7 +14,7 @@ class PredictionSubmitSerializer(serializers.Serializer):
         child=serializers.FloatField(), min_length=4, max_length=4, required=False
     )
     geometry = serializers.JSONField(required=False)
-    zoom = serializers.IntegerField(min_value=_MIN_ZOOM, max_value=_MAX_ZOOM)
+    zoom = serializers.IntegerField(min_value=MIN_ZOOM, max_value=MAX_ZOOM)
     params = serializers.DictField(required=False, default=dict)
     remove_osm = serializers.BooleanField(
         required=False,

--- a/backend/shared/serializers.py
+++ b/backend/shared/serializers.py
@@ -1,5 +1,13 @@
 from rest_framework import serializers
 
+# Placeholders a TMS tile URL template must contain
+TMS_PLACEHOLDERS = ("{x}", "{y}", "{z}")
+
+# TMS tile zoom bounds accepted for dataset creation and prediction submission
+# (not the config-driven PMTiles generation range).
+MIN_ZOOM = 14
+MAX_ZOOM = 22
+
 
 class StacAssetSerializer(serializers.Serializer):
     href = serializers.CharField()


### PR DESCRIPTION
Three values in the backend are written out in more than one place, so a change to one of them can silently miss the others.

- `("{x}", "{y}", "{z}")` - the placeholders a TMS URL template must contain - is defined as a private `_TMS_PLACEHOLDERS` in both `datasets/serializers.py` and `modelregistry/serializers.py`, and both use it to build the same validation error.
- The accepted tile zoom range 14..22 is `_MIN_ZOOM`/`_MAX_ZOOM` in `predictions/serializers.py` and bare `min_value=14, max_value=22` in `DatasetCreateSerializer`. These two are meant to agree: a dataset is created at a zoom, then predictions are submitted at one.
- `datasets/tasks.py` builds the labels path with a literal `"labels.geojson"`, while `StoragePaths.LABELS_GEOJSON_FILENAME` already holds exactly that string and is what the rest of the storage helpers use.

The two constants now live in `shared/serializers.py`, next to the serializers that already import from there, and the filename comes from `StoragePaths`. Values are unchanged, so this is behaviour-neutral.

I left the config-driven PMTiles zoom range alone - it is a different setting that happens to overlap, and I noted that in the comment above the new constants.

`ruff check`, `ruff format --check`, `ty check` and `uv lock --check` all pass.
